### PR TITLE
chore: give main ci job a name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
     push:
 
 jobs:
-
+  name: main-ci-job
   build:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
This should allow it to then be made a mandatory check before a merge can be made. Currently its possible to merge in a PR before the CI run completes.