### PR TITLE
feat: better performance logging.

### DIFF
--- a/native/app/core/DataService.ts
+++ b/native/app/core/DataService.ts
@@ -72,7 +72,10 @@ class DataService {
 
   public static async getInventory() {
     try {
+      const pa1 = performance.now();
       const profile = await getProfile();
+      const pa2 = performance.now();
+      console.log("getProfile() took:", (pa2 - pa1).toFixed(4), "ms");
       const p1 = performance.now();
 
       const validatedProfile = parse(getProfileSchema, profile);

--- a/native/app/screens/Home.tsx
+++ b/native/app/screens/Home.tsx
@@ -259,9 +259,6 @@ export default function HomeScreen({ navigation }: { navigation: NavigationProp<
 
   useEffect(() => {
     if (globalState.dataIsReady) {
-      const p3 = performance.now();
-      console.log("dataIsReady took:", (p3 - p1).toFixed(4), "ms");
-
       buildUIData();
     }
   }, [globalState.dataIsReady]);


### PR DESCRIPTION
Previously the time it took the bungie api to respond with getProfile was logged as part of the general startup. As the client has no control over how responsive bungie's servers are this is now seperated out.

