### PR TITLE
fix: Some icons were missing season overlay

### DIFF
--- a/native/app/core/DataService.ts
+++ b/native/app/core/DataService.ts
@@ -197,7 +197,7 @@ class DataService {
         const data = DataService.itemDefinition.items[itemHash] as SingleItemDefinition;
 
         const bucketHashIndex = data.b;
-        if (bucketHashIndex) {
+        if (bucketHashIndex !== undefined) {
           const definitionBucketHash = DataService.bucketTypeHashArray[bucketHashIndex];
 
           if (definitionBucketHash) {

--- a/native/app/inventory/UiDataBuilder.ts
+++ b/native/app/inventory/UiDataBuilder.ts
@@ -195,12 +195,14 @@ function returnDestinyIconData(item: DestinyItem): DestinyIconData {
     if (itemComponent) {
       // if it has a version number get the watermark from the array. If it does not then see if the definition has an 'iconWatermark'
       const versionNumber = item.versionNumber;
+
       let watermark: string | undefined = undefined;
-      if (versionNumber) {
+      if (versionNumber !== undefined) {
         const dvwi = definition.dvwi;
+
         if (dvwi) {
           const index = dvwi[versionNumber];
-          if (index) {
+          if (index !== undefined) {
             watermark = DataService.IconWaterMarks[index];
           }
         }


### PR DESCRIPTION
Root cause: there was code that returned false e.g. if (index), but the index was 0. A legitamte value for an index. So the code has been updated to instead be `if (index !== undefined). These are for values extracted from JSON so if there is no value at all, it will be undefined.