### PR TITLE
refactor: basic support for non instanced items

### DIFF
--- a/native/app/RootScreen.tsx
+++ b/native/app/RootScreen.tsx
@@ -12,7 +12,7 @@ import { Platform, useColorScheme } from "react-native";
 export type RootStackParamList = {
   Login: undefined;
   Root: undefined;
-  BottomSheet: { itemInstanceId: string; itemHash: number };
+  BottomSheet: { itemInstanceId: string | undefined; itemHash: number };
 };
 
 const RootStack = createStackNavigator<RootStackParamList>();

--- a/native/app/inventory/Common.ts
+++ b/native/app/inventory/Common.ts
@@ -17,12 +17,11 @@ export const armorPageBuckets = [
 
 export const inventoryPageBuckets = [
   375726501, // Engrams undefined 444348033 undefined 497170007
-  // 215593132, // LostItems
+  215593132, // LostItems
   4274335291, // Emblems
   284967655, // Ships
   2025709351, // Vehicle
   3683254069, // Finisher
-  3054419239, // Emotes
 ];
 
 export enum DamageType {

--- a/native/app/inventory/UiDataBuilder.ts
+++ b/native/app/inventory/UiDataBuilder.ts
@@ -36,6 +36,7 @@ export function buildUIData(itemBuckets: Array<number>): Array<Array<UiCell>> {
         if (bucketItems) {
           const equipped = bucketItems.equipped;
           let equipItem: DestinyIconData | null = null;
+
           if (equipped) {
             equipItem = returnDestinyIconData(equipped);
             const equippedCell: DestinyCell = {

--- a/native/app/inventory/UiRowRenderItem.tsx
+++ b/native/app/inventory/UiRowRenderItem.tsx
@@ -7,12 +7,12 @@ import { TouchableOpacity } from "react-native";
 
 export const UiCellRenderItem = (
   { item }: { item: UiCell },
-  handlePress: (itemInstanceId: string, itemHash: number) => void,
+  handlePress: (itemInstanceId: string | undefined, itemHash: number) => void,
 ) => {
   return (
     <TouchableOpacity
       onPress={() => {
-        if (item.itemInstanceId && item.itemHash) {
+        if (item.itemHash) {
           handlePress(item.itemInstanceId, item.itemHash);
         }
       }}

--- a/native/app/screens/BottomSheet.tsx
+++ b/native/app/screens/BottomSheet.tsx
@@ -8,13 +8,13 @@ import { safeParse } from "valibot";
 import { itemSchema } from "@/app/core/Types.ts";
 
 type ViewData = {
-  itemInstanceId: string;
+  itemInstanceId: string | undefined;
   itemTypeDisplayName: string;
   screenshot: string;
   name: string;
 };
 
-function buildViewData(itemInstanceId: string, itemHash: number): ViewData {
+function buildViewData(itemInstanceId: string | undefined, itemHash: number): ViewData {
   const p1 = performance.now();
   const itemDef = safeParse(itemSchema, DataService.itemDefinition.items[itemHash]);
   if (itemDef.success) {

--- a/native/app/screens/InventoryPage.tsx
+++ b/native/app/screens/InventoryPage.tsx
@@ -38,7 +38,7 @@ export default function InventoryPage(props: InventoryPageProps) {
     }
   }, [globalState.dataIsReady, props.itemBuckets]);
 
-  function activateSheet(itemInstanceIdArg: string, itemHashArg: number) {
+  function activateSheet(itemInstanceIdArg: string | undefined, itemHashArg: number) {
     navigator.navigate("BottomSheet", { itemInstanceId: itemInstanceIdArg, itemHash: itemHashArg });
   }
 


### PR DESCRIPTION
Non instanced items have an itemHash but no itemInstanceId. The app now has basic handling for these, but only enough to render lost items.