### PR TITLE
fix(state): No inventory shows on app launch

### DIFF
--- a/native/app/store/AuthenticationSlice.ts
+++ b/native/app/store/AuthenticationSlice.ts
@@ -60,7 +60,7 @@ export const createAuthenticationSlice: StateCreator<AuthenticationSlice> = (set
         const membershipId = get().bungieUser.profile.membershipId;
         saveToken(validToken, membershipId);
         set({ authToken: validToken, systemDisabled: false });
-        return authToken;
+        return validToken;
       }
     }
 


### PR DESCRIPTION
The previous (stale) token was returned instead of the new valid token.