### PR TITLE
fix(UX): On logout also clear any inventory lists

### DIFF
--- a/native/app/store/AuthenticationSlice.ts
+++ b/native/app/store/AuthenticationSlice.ts
@@ -100,7 +100,14 @@ export const createAuthenticationSlice: StateCreator<
   logoutCurrentUser: () => {
     const membershipId = get().bungieUser.profile.membershipId;
     deleteUserData(membershipId);
-    set({ bungieUser: initialBungieUser, authToken: null, authenticated: "NO-AUTHENTICATION" });
+    set({
+      bungieUser: initialBungieUser,
+      authToken: null,
+      authenticated: "NO-AUTHENTICATION",
+      armorPageData: [],
+      generalPageData: [],
+      weaponsPageData: [],
+    });
   },
   createAuthenticatedAccount: async (url: string) => {
     try {


### PR DESCRIPTION
Before this you would see the previous users list if you logged right back in after a logout.