### PR TITLE
refactor: Add characterId to all destinyItem's

### DIFF
--- a/native/app/bungie/Types.ts
+++ b/native/app/bungie/Types.ts
@@ -133,7 +133,10 @@ export const ItemSchema = object({
   versionNumber: optional(number()),
 });
 
-export type DestinyItem = Output<typeof ItemSchema>;
+export type DestinyItemBase = Output<typeof ItemSchema>;
+export type DestinyItem = DestinyItemBase & {
+  characterId: string;
+};
 
 export const GuardiansSchema = object({
   baseCharacterLevel: number(),


### PR DESCRIPTION
It will be simpler for the transfer system to know what character an item is on if the item data itself holds that info