### PR TITLE
refactor(transfer): Simplify the system

### DIFF
--- a/native/app/bungie/Types.ts
+++ b/native/app/bungie/Types.ts
@@ -132,6 +132,7 @@ export type DestinyItemBase = Output<typeof ItemSchema>;
 export type DestinyItem = DestinyItemBase & {
   characterId: string;
   equipped: boolean;
+  previousCharacterId: string; //Used by the transfer system to update the UI
 };
 
 export const GuardiansSchema = object({

--- a/native/app/transfer/TransferLogic.ts
+++ b/native/app/transfer/TransferLogic.ts
@@ -162,7 +162,9 @@ export async function processTransferItem(
 
         if (parsedResult.success) {
           if (parsedResult.output.ErrorStatus === "Success") {
-            return processTransferItem(toCharacterId, result[1], quantityToMove, equipOnTarget);
+            processTransferItem(toCharacterId, result[1], quantityToMove, equipOnTarget);
+            useGGStore.getState().moveItem(result[1]);
+            return;
           }
           console.error("Failed", parsedResult.output);
           useGGStore.getState().showSnackBar(`Failed to transfer item ${parsedResult.output.Message} `);
@@ -254,10 +256,13 @@ async function moveItem(transferItem: TransferItem): Promise<[JSON, DestinyItem]
           return response.json();
         })
         .then((data) => {
-          const fromCharacterId = transferItem.destinyItem.characterId;
+          const previousCharacterId = transferItem.destinyItem.characterId;
           const updatedCharacterId = toVault ? VAULT_CHARACTER_ID : transferItem.finalTargetId;
-          const updatedDestinyItem: DestinyItem = { ...transferItem.destinyItem, characterId: updatedCharacterId };
-          useGGStore.getState().moveItem(updatedDestinyItem, fromCharacterId);
+          const updatedDestinyItem: DestinyItem = {
+            ...transferItem.destinyItem,
+            characterId: updatedCharacterId,
+            previousCharacterId,
+          };
           resolve([data as JSON, updatedDestinyItem]);
         })
         .catch((error) => {


### PR DESCRIPTION
This adds a 'previousCharacterId' property to allow the UI to update. Without this the moveItem store setter would not know where an item has moved between. which would have meant transferItem() or the acual move function would have to track and manager that.

The zustand states are also slightly simplified by better use of the 'mutative' helper library.