### PR TITLE
refactor: Simplify how the bottomsheet is shown

### DIFF
--- a/native/app/App.tsx
+++ b/native/app/App.tsx
@@ -10,16 +10,16 @@ import MainDrawer from "@/app/screens/MainDrawer.tsx";
 import Login from "@/app/screens/Login.tsx";
 import { Platform } from "react-native";
 import BottomSheet from "@/app/screens/BottomSheet.tsx";
-import type { UiCell } from "@/app/inventory/Common.ts";
 import GGSnackBar from "@/app/components/GGSnackBar.tsx";
 import { enableFreeze } from "react-native-screens";
+import type { DestinyItem } from "@/app/bungie/Types.ts";
 
 enableFreeze(true);
 
 type RootStackParamList = {
   Login: undefined;
   Root: undefined;
-  BottomSheet: { item: UiCell };
+  BottomSheet: { item: DestinyItem };
 };
 
 const RootStack = createStackNavigator<RootStackParamList>();

--- a/native/app/inventory/Common.ts
+++ b/native/app/inventory/Common.ts
@@ -151,6 +151,12 @@ export type HeaderRow = {
 
 export type UiRow = HeaderRow | CharacterEquippedRow | CharacterInventoryRow | VaultInventoryRow;
 
+export type DestinyItemIdentifier = {
+  itemHash: number;
+  itemInstanceId: string | undefined;
+  characterId: string;
+};
+
 export const ITEM_SIZE = 90;
 export const SEPARATOR_SIZE = 45;
 

--- a/native/app/inventory/DestinyCell.tsx
+++ b/native/app/inventory/DestinyCell.tsx
@@ -1,7 +1,8 @@
 import { ITEM_SIZE } from "@/app/inventory/Common.ts";
+import { useGGStore } from "@/app/store/GGStore.ts";
 import { Image } from "expo-image";
 import React from "react";
-import { StyleSheet, Text, View } from "react-native";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
 const DEFAULT_BORDER_COLOR = "#3E3D45";
 const MINI_ICON_SIZE = 17;
@@ -87,41 +88,52 @@ type DestinyCellProps = {
   calculatedWaterMark: string | undefined;
   masterwork: boolean;
   crafted: boolean;
+  itemHash: number;
+  itemInstanceId: string | undefined;
+  characterId: string;
 };
+
+function handlePress(item: DestinyCellProps) {
+  useGGStore
+    .getState()
+    .setSelectedItem({ itemInstanceId: item.itemInstanceId, itemHash: item.itemHash, characterId: item.characterId });
+}
 
 const DestinyCell = (props: DestinyCellProps) => {
   const borderColor = props.masterwork ? "#CEAE32" : "#555555";
 
   return (
     <View style={styles.container}>
-      <View style={styles.frameSize}>
-        <View style={[styles.icon, { borderColor }]}>
-          <View style={styles.innerFrameSize}>
-            <Image
-              source={{ uri: props.iconUri }}
-              cachePolicy="memory-disk"
-              style={styles.innerFrameSize}
-              recyclingKey={props.iconUri}
-            />
-            <Image
-              source={{ uri: props.calculatedWaterMark }}
-              cachePolicy="memory-disk"
-              style={styles.innerFrameOverlaySize}
-              recyclingKey={props.calculatedWaterMark}
-            />
+      <TouchableOpacity onPress={handlePress.bind(this, props)}>
+        <View style={styles.frameSize}>
+          <View style={[styles.icon, { borderColor }]}>
+            <View style={styles.innerFrameSize}>
+              <Image
+                source={{ uri: props.iconUri }}
+                cachePolicy="memory-disk"
+                style={styles.innerFrameSize}
+                recyclingKey={props.iconUri}
+              />
+              <Image
+                source={{ uri: props.calculatedWaterMark }}
+                cachePolicy="memory-disk"
+                style={styles.innerFrameOverlaySize}
+                recyclingKey={props.calculatedWaterMark}
+              />
+            </View>
           </View>
+          {props.primaryStat !== "" && (
+            <View style={styles.powerLevel}>
+              <Text style={styles.powerLevelText}>{props.primaryStat}</Text>
+            </View>
+          )}
+          {props.damageTypeIconUri && (
+            <View style={styles.miniIconBurn}>
+              <Image style={styles.miniIconBurnSize} source={props.damageTypeIconUri} cachePolicy="memory" />
+            </View>
+          )}
         </View>
-        {props.primaryStat !== "" && (
-          <View style={styles.powerLevel}>
-            <Text style={styles.powerLevelText}>{props.primaryStat}</Text>
-          </View>
-        )}
-        {props.damageTypeIconUri && (
-          <View style={styles.miniIconBurn}>
-            <Image style={styles.miniIconBurnSize} source={props.damageTypeIconUri} cachePolicy="memory" />
-          </View>
-        )}
-      </View>
+      </TouchableOpacity>
     </View>
   );
 };

--- a/native/app/inventory/UiRowRenderItem.tsx
+++ b/native/app/inventory/UiRowRenderItem.tsx
@@ -3,38 +3,28 @@ import { type UiCell, UiCellType } from "@/app/inventory/Common.ts";
 import DestinyCell from "@/app/inventory/DestinyCell.tsx";
 import EmptyCell from "@/app/inventory/EmptyCell.tsx";
 import SeparatorCell from "@/app/inventory/SeparatorCell.tsx";
-import { TouchableOpacity } from "react-native";
 
-export const UiCellRenderItem = ({ item }: { item: UiCell }, handlePress: (item: UiCell) => void) => {
-  return (
-    <TouchableOpacity
-      onPress={() => {
-        if (item.type === UiCellType.DestinyCell && item.itemHash) {
-          handlePress(item);
-        }
-      }}
-    >
-      {(() => {
-        switch (item.type) {
-          case UiCellType.Separator:
-            return <SeparatorCell />;
-          case UiCellType.EmptyCell:
-            return <EmptyCell />;
-          case UiCellType.BlankCell:
-            return <BlankCell />;
-          case UiCellType.DestinyCell:
-            return (
-              <DestinyCell
-                iconUri={item.icon}
-                primaryStat={item.primaryStat}
-                calculatedWaterMark={item.calculatedWaterMark}
-                damageTypeIconUri={item.damageTypeIconUri}
-                masterwork={item.masterwork}
-                crafted={item.crafted}
-              />
-            );
-        }
-      })()}
-    </TouchableOpacity>
-  );
+export const UiCellRenderItem = ({ item }: { item: UiCell }) => {
+  switch (item.type) {
+    case UiCellType.Separator:
+      return <SeparatorCell />;
+    case UiCellType.EmptyCell:
+      return <EmptyCell />;
+    case UiCellType.BlankCell:
+      return <BlankCell />;
+    case UiCellType.DestinyCell:
+      return (
+        <DestinyCell
+          iconUri={item.icon}
+          primaryStat={item.primaryStat}
+          calculatedWaterMark={item.calculatedWaterMark}
+          damageTypeIconUri={item.damageTypeIconUri}
+          masterwork={item.masterwork}
+          crafted={item.crafted}
+          itemHash={item.itemHash}
+          itemInstanceId={item.itemInstanceId}
+          characterId={item.characterId}
+        />
+      );
+  }
 };

--- a/native/app/screens/BottomSheet.tsx
+++ b/native/app/screens/BottomSheet.tsx
@@ -1,9 +1,8 @@
 import type { DestinyItem } from "@/app/bungie/Types.ts";
-import type { DestinyCell } from "@/app/inventory/Common.ts";
 import { itemTypeDisplayName, itemsDefinition } from "@/app/store/Definitions.ts";
 import { useGGStore } from "@/app/store/GGStore.ts";
 import { itemSchema } from "@/app/store/Types";
-import { findDestinyItem, processTransferItem } from "@/app/transfer/TransferLogic.ts";
+import { processTransferItem } from "@/app/transfer/TransferLogic.ts";
 import { VAULT_CHARACTER_ID } from "@/app/utilities/Constants.ts";
 import type { NavigationProp, RouteProp } from "@react-navigation/native";
 import { Image } from "expo-image";
@@ -224,9 +223,9 @@ export default function BottomSheet({
   const refRBSheet = useRef<RBSheet>(null);
   const { width } = useWindowDimensions();
   const SCREEN_WIDTH = width;
-  const { itemInstanceId, itemHash, characterId } = route.params.item as DestinyCell;
+  const { itemInstanceId, itemHash, characterId } = route.params.item;
   const [viewData, _setViewData] = useState<ViewData>(buildViewData(itemInstanceId, itemHash));
-  const destinyItem = { ...findDestinyItem(itemInstanceId, itemHash, characterId) };
+  const destinyItem = { ...useGGStore.getState().findDestinyItem({ itemInstanceId, itemHash, characterId }) };
 
   useEffect(() => {
     if (refRBSheet.current) {

--- a/native/app/screens/InventoryPage.tsx
+++ b/native/app/screens/InventoryPage.tsx
@@ -3,7 +3,7 @@ import { UiCellRenderItem } from "@/app/inventory/UiRowRenderItem.tsx";
 import { calcCurrentListIndex } from "@/app/screens/Helpers.ts";
 import { useGGStore } from "@/app/store/GGStore.ts";
 import { debounce } from "@/app/utilities/Helpers.ts";
-import { useIsFocused, useNavigation } from "@react-navigation/native";
+import { useIsFocused } from "@react-navigation/native";
 import { FlashList } from "@shopify/flash-list";
 import { useCallback, useEffect, useRef } from "react";
 import { StyleSheet, View, useWindowDimensions } from "react-native";
@@ -24,9 +24,15 @@ const rootStyles = StyleSheet.create({
   },
 });
 
+const renderItem = ({ item }: { item: UiCell }) => {
+  return UiCellRenderItem({ item });
+};
+
+const keyExtractor = (item: UiCell) => item.id;
+const getItemType = (item: UiCell) => item.type;
+
 export default function InventoryPage(props: InventoryPageProps) {
   const currentListIndex = useGGStore((state) => state.currentListIndex);
-  const navigator = useNavigation();
   const { width } = useWindowDimensions();
   const HOME_WIDTH = width;
 
@@ -54,10 +60,6 @@ export default function InventoryPage(props: InventoryPageProps) {
     }
   }, [isFocused]);
 
-  function activateSheet(item: UiCell) {
-    navigator.navigate("BottomSheet", { item });
-  }
-
   // Keeps the non vault list in sync with each other. So if you scroll to energy weapons on guardian 1
   // when you horizontally scroll to guardian 2 you will see it's energy weapons too.
   function listMoved(toY: number) {
@@ -78,15 +80,8 @@ export default function InventoryPage(props: InventoryPageProps) {
 
   const debouncedMove = debounce(listMoved, 60);
 
-  const renderItem = ({ item }: { item: UiCell }) => {
-    return UiCellRenderItem({ item }, activateSheet);
-  };
-
-  const keyExtractor = (item: UiCell) => item.id;
-  const getItemType = (item: UiCell) => item.type;
-
   const onLoadListener = useCallback(({ elapsedTimeInMs }: { elapsedTimeInMs: number }) => {
-    console.log("Sample List load time", elapsedTimeInMs);
+    console.log("FlashList load time", elapsedTimeInMs);
   }, []);
 
   return (

--- a/native/app/screens/MainDrawer.tsx
+++ b/native/app/screens/MainDrawer.tsx
@@ -1,10 +1,13 @@
 import { getFullProfile } from "@/app/bungie/BungieApi.ts";
 import type { GuardianClassType } from "@/app/bungie/Hashes.ts";
+import type { DestinyItem } from "@/app/bungie/Types.ts";
 import { LOGO_DARK } from "@/app/inventory/Common.ts";
 import InventoryHeader from "@/app/screens/InventoryHeader.tsx";
 import InventoryPages from "@/app/screens/InventoryPages";
 import { useGGStore } from "@/app/store/GGStore.ts";
 import { type DrawerContentComponentProps, createDrawerNavigator } from "@react-navigation/drawer";
+import { useNavigation } from "@react-navigation/native";
+import { useEffect } from "react";
 import { Image, StyleSheet, Text, View } from "react-native";
 import { Button, IconButton } from "react-native-paper";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -92,6 +95,18 @@ export default function MainDrawer() {
   const ggGuardians = useGGStore((state) => state.ggCharacters);
   const currentListIndex = useGGStore((state) => state.currentListIndex);
   const guardianClassType = getGuardianClassType(ggGuardians[currentListIndex]?.guardianClassType);
+  const navigator = useNavigation();
+  const selectedItem = useGGStore((state) => state.selectedItem);
+
+  function activateSheet(item: DestinyItem) {
+    navigator.navigate("BottomSheet", { item });
+  }
+
+  useEffect(() => {
+    if (selectedItem) {
+      activateSheet(selectedItem);
+    }
+  }, [selectedItem]);
 
   return (
     <Drawer.Navigator

--- a/native/app/store/AccountLogic.ts
+++ b/native/app/store/AccountLogic.ts
@@ -5,8 +5,11 @@ import {
   type Guardian,
   type GuardianData,
   GuardiansSchema,
+  type DestinyItem,
 } from "@/app/bungie/Types.ts";
 import { bungieUrl } from "@/app/inventory/Common.ts";
+import type { AccountSliceGetter } from "@/app/store/AccountSlice.ts";
+import { bucketTypeHashArray, itemsDefinition } from "@/app/store/Definitions.ts";
 import { VAULT_CHARACTER_ID } from "@/app/utilities/Constants.ts";
 import { safeParse } from "valibot";
 
@@ -60,4 +63,79 @@ function addCharacterDefinition(guardianData: GuardianData): GGCharacterUiData {
   };
 
   return data;
+}
+
+// These are the fewest arguments possible. itemInstanceId would be enough for all instanced items. But for non
+// instanced the characterId and itemHash are needed. Because you could have a non instanced item such as upgrade
+// materials in the lost items of two different characters. So the characterId is needed to find the correct item.
+// TODO: This function does not check the global items, mods or consumables.
+export function findDestinyItem(
+  get: AccountSliceGetter,
+  itemInstanceId: string | undefined,
+  itemHash: number,
+  characterId: string,
+): DestinyItem {
+  const itemDefinition = itemsDefinition[itemHash];
+  if (!itemDefinition) {
+    throw new Error("No itemDefinition found");
+  }
+
+  if (itemDefinition.b !== undefined) {
+    const defaultBucket = bucketTypeHashArray[itemDefinition.b];
+
+    const instancedItem = itemInstanceId !== undefined;
+    if (defaultBucket) {
+      if (characterId === VAULT_CHARACTER_ID) {
+        const vault = get().generalVault;
+        const vaultSectionInventory = vault.items[defaultBucket]?.inventory;
+        if (vaultSectionInventory) {
+          for (const item of vaultSectionInventory) {
+            if (instancedItem) {
+              if (item.itemInstanceId === itemInstanceId) {
+                return item;
+              }
+            } else {
+              if (item.itemHash === itemHash) {
+                return item;
+              }
+            }
+          }
+        }
+      } else {
+        const guardians = get().guardians;
+        const section = guardians[characterId]?.items[defaultBucket];
+
+        if (section) {
+          if (section.equipped && section.equipped?.itemInstanceId === itemInstanceId) {
+            return section.equipped;
+          }
+
+          for (const item of section.inventory) {
+            if (item.itemInstanceId === itemInstanceId) {
+              return item;
+            }
+          }
+        }
+
+        // Check the lost items
+        const lostItems = guardians[characterId]?.items[215593132]?.inventory;
+        if (lostItems) {
+          for (const item of lostItems) {
+            if (instancedItem) {
+              if (item.itemInstanceId === itemInstanceId) {
+                return item;
+              }
+            } else {
+              if (item.itemHash === itemHash) {
+                return item;
+              }
+            }
+          }
+        }
+      }
+    } else {
+      console.error("No default bucket");
+    }
+  }
+  throw new Error("No DestinyItem found");
 }

--- a/native/app/transfer/TransferLogic.ts
+++ b/native/app/transfer/TransferLogic.ts
@@ -1,6 +1,6 @@
 import type { DestinyItem } from "@/app/bungie/Types.ts";
 import { basePath } from "@/app/inventory/Common.ts";
-import { bucketTypeHashArray, itemsDefinition } from "@/app/store/Definitions.ts";
+import { itemsDefinition } from "@/app/store/Definitions.ts";
 import { useGGStore } from "@/app/store/GGStore.ts";
 import { VAULT_CHARACTER_ID } from "@/app/utilities/Constants.ts";
 import { apiKey } from "@/constants/env.ts";
@@ -23,80 +23,6 @@ export type TransferItem = {
   quantityToMove: number;
   equipOnTarget: boolean;
 };
-
-// These are the fewest arguments possible. itemInstanceId would be enough for all instanced items. But for non
-// instanced the characterId and itemHash are needed. Because you could have a non instanced item such as upgrade
-// materials in the lost items of two different characters. So the characterId is needed to find the correct item.
-// TODO: This function does not check the global items, mods or consumables.
-export function findDestinyItem(
-  itemInstanceId: string | undefined,
-  itemHash: number,
-  characterId: string,
-): DestinyItem {
-  const itemDefinition = itemsDefinition[itemHash];
-  if (!itemDefinition) {
-    throw new Error("No itemDefinition found");
-  }
-
-  if (itemDefinition.b !== undefined) {
-    const defaultBucket = bucketTypeHashArray[itemDefinition.b];
-
-    const instancedItem = itemInstanceId !== undefined;
-    if (defaultBucket) {
-      if (characterId === VAULT_CHARACTER_ID) {
-        const vault = useGGStore.getState().generalVault;
-        const vaultSectionInventory = vault.items[defaultBucket]?.inventory;
-        if (vaultSectionInventory) {
-          for (const item of vaultSectionInventory) {
-            if (instancedItem) {
-              if (item.itemInstanceId === itemInstanceId) {
-                return item;
-              }
-            } else {
-              if (item.itemHash === itemHash) {
-                return item;
-              }
-            }
-          }
-        }
-      } else {
-        const guardians = useGGStore.getState().guardians;
-        const section = guardians[characterId]?.items[defaultBucket];
-
-        if (section) {
-          if (section.equipped && section.equipped?.itemInstanceId === itemInstanceId) {
-            return section.equipped;
-          }
-
-          for (const item of section.inventory) {
-            if (item.itemInstanceId === itemInstanceId) {
-              return item;
-            }
-          }
-        }
-
-        // Check the lost items
-        const lostItems = guardians[characterId]?.items[215593132]?.inventory;
-        if (lostItems) {
-          for (const item of lostItems) {
-            if (instancedItem) {
-              if (item.itemInstanceId === itemInstanceId) {
-                return item;
-              }
-            } else {
-              if (item.itemHash === itemHash) {
-                return item;
-              }
-            }
-          }
-        }
-      }
-    } else {
-      console.error("No default bucket");
-    }
-  }
-  throw new Error("No DestinyItem found");
-}
 
 export async function processTransferItem(
   toCharacterId: string,


### PR DESCRIPTION
This goes deeper than the bottomsheet. It puts a findDestinyItem on the store where it can be used by the entire app. 

DestinyItem is used to pass around data. And not UiCell which is just an extra step and confusing. UiCell should just be for building UI elements.