### PR TITLE
refactor(getProfile): Simplify validation but keep complex type

### DIFF
--- a/native/app/bungie/BungieApi.ts
+++ b/native/app/bungie/BungieApi.ts
@@ -1,4 +1,4 @@
-import { getProfileSchema, type ProfileData } from "@/app/bungie/Types.ts";
+import { getProfileSimpleSchema, type ProfileData } from "@/app/bungie/Types.ts";
 import { basePath } from "@/app/inventory/Common.ts";
 import { useGGStore } from "@/app/store/GGStore.ts";
 import { apiKey } from "@/constants/env.ts";
@@ -10,14 +10,13 @@ export async function getFullProfile() {
   useGGStore.getState().setRefreshing(true);
   try {
     const profile = (await getProfile()) as unknown as ProfileData;
-
     // The returned data is often old and won't reflect recent transfers. This check ensures the data
     // has a newer timestamp than the previous data.
     const isNewer = isProfileNewer(profile);
     if (isNewer) {
-      const validatedProfile = safeParse(getProfileSchema, profile);
+      const validatedProfile = safeParse(getProfileSimpleSchema, profile);
       if (validatedProfile.success) {
-        useGGStore.getState().updateProfile(validatedProfile.output);
+        useGGStore.getState().updateProfile(validatedProfile.output as ProfileData);
       } else {
         console.error("Failed to validate profile!", profile);
         console.error("Issues", validatedProfile.issues);

--- a/native/app/bungie/Types.ts
+++ b/native/app/bungie/Types.ts
@@ -1,6 +1,6 @@
 import type { GuardianClassType, GuardianGenderType, GuardianRaceType } from "@/app/bungie/Hashes.ts";
 import type { DamageType, DestinyItemType } from "@/app/inventory/Common.ts";
-import { array, boolean, isoTimestamp, merge, number, object, optional, record, string } from "valibot";
+import { array, boolean, isoTimestamp, merge, number, object, optional, record, string, unknown } from "valibot";
 import type { Output } from "valibot";
 
 export type GuardiansAndVault = {
@@ -223,6 +223,38 @@ const PlugSetSchema = array(
 
 export type PlugSet = Output<typeof PlugSetSchema>;
 
+const itemComponentSchema = record(
+  string(),
+  object({
+    canEquip: boolean(),
+    cannotEquipReason: number(),
+    damageType: number(),
+    damageTypeHash: optional(number()),
+    energy: optional(
+      object({
+        energyCapacity: number(),
+        energyType: number(),
+        energyTypeHash: number(),
+        energyUnused: number(),
+        energyUsed: number(),
+      }),
+    ),
+    equipRequiredLevel: number(),
+    isEquipped: boolean(),
+    itemLevel: number(),
+    primaryStat: optional(
+      object({
+        statHash: number(),
+        value: number(),
+      }),
+    ),
+    quality: number(),
+    unlockHashesRequiredToEquip: array(number()),
+  }),
+);
+
+export type ItemComponent = Output<typeof itemComponentSchema>;
+
 export const getProfileSchema = merge([
   bungieResponseSchema,
   object({
@@ -298,6 +330,52 @@ export const getProfileSchema = merge([
 ]);
 
 export type ProfileData = Output<typeof getProfileSchema>;
+
+export const getProfileSimpleSchema = merge([
+  bungieResponseSchema,
+  object({
+    Response: object({
+      characterEquipment: object({
+        data: record(string(), unknown()), //object({ items: array(ItemSchema) })),
+        privacy: number(),
+      }),
+      characterInventories: object({
+        data: unknown(), //record(string(), object({ items: array(ItemSchema) })),
+      }),
+      characterLoadouts: object({}),
+      characterPlugSets: object({}),
+      characterProgressions: object({}),
+      characterStringVariables: object({}),
+      characterUninstancedItemComponents: object({}),
+      characters: object({
+        data: record(string(), unknown()), //GuardiansSchema),
+      }),
+
+      itemComponents: object({
+        instances: object({
+          data: unknown(), //itemComponentSchema,
+        }),
+        sockets: object({
+          data: unknown(), //record(string(), SocketSchema),
+        }),
+      }),
+      profile: object({}),
+      profileCurrencies: object({}),
+      profileInventory: object({
+        data: object({ items: unknown() }), //array(ItemSchema) }),
+      }),
+      profilePlugSets: object({
+        data: object({
+          plugs: unknown(), //record(string(), PlugSetSchema),
+        }),
+      }),
+      profileProgression: object({}),
+      profileStringVariables: object({}),
+      responseMintedTimestamp: string([isoTimestamp()]),
+      secondaryComponentsMintedTimestamp: string([isoTimestamp()]),
+    }),
+  }),
+]);
 
 export enum GGCharacterType {
   Guardian = 0,


### PR DESCRIPTION
The Valibot validation of getProfile takes 100ms of a high end laptop. It's not strictly necessary as in most cases the profile is either fine or totally broken. So a simple validation for the main sections is enough for validation. Then the full type can be applied to it for autocomplete.