### PR TITLE
feature: GG Web uses its own oath redirect

### DIFF
--- a/native/constants/env.ts
+++ b/native/constants/env.ts
@@ -10,4 +10,5 @@ export const clientSecret: string = !isLocalWeb
   ? process.env.EXPO_PUBLIC_CLIENT_SECRET
   : process.env.EXPO_PUBLIC_CLIENT_SECRET_WEB;
 
-export const redirectURL = "https://app.guardianghost.com/auth";
+export const redirectURL =
+  Platform.OS === "web" ? "https://app.guardianghost.com/oauth" : "https://app.guardianghost.com/auth";


### PR DESCRIPTION
This stops the issue where authing the web version on your phone would cause the native mobile app to open and stop the auth competing. Users can now easily use both the native and web site on the same device