### PR TITLE
refactor: Auto refresh can be reset more easily

### DIFF
--- a/native/app/App.tsx
+++ b/native/app/App.tsx
@@ -69,7 +69,6 @@ function App() {
   const navigationRef = useRef<NavigationContainerRef<ReactNavigation.RootParamList>>(null);
   const { width } = useWindowDimensions();
   const SCREEN_WIDTH = width;
-  const lastRefreshRef = useRef<number>(0);
 
   useEffect(() => {
     if (SCREEN_WIDTH) {
@@ -86,8 +85,7 @@ function App() {
       }
     } else if (authenticated === "AUTHENTICATED" && definitionsReady) {
       getFullProfile();
-      const now = performance.now();
-      lastRefreshRef.current = now;
+      useGGStore.getState().setLastRefreshTime();
       const intervalId = setInterval(refreshIfNeeded, 2000);
 
       return () => clearInterval(intervalId);
@@ -95,11 +93,10 @@ function App() {
   }, [authenticated, definitionsReady]);
 
   function refreshIfNeeded() {
-    const lastRefresh = lastRefreshRef.current;
+    const lastRefresh = useGGStore.getState().lastRefreshTime;
     const now = performance.now();
     if (now - lastRefresh > 35000) {
       getFullProfile();
-      lastRefreshRef.current = now;
     }
   }
 

--- a/native/app/bungie/BungieApi.ts
+++ b/native/app/bungie/BungieApi.ts
@@ -7,6 +7,7 @@ import { isoTimestamp, safeParse, string } from "valibot";
 export const profileComponents = "100,102,103,104,200,201,202,205,206,300,301,305,307,309,310,1200";
 
 export async function getFullProfile() {
+  useGGStore.getState().setLastRefreshTime();
   useGGStore.getState().setRefreshing(true);
   try {
     const profile = (await getProfile()) as unknown as ProfileData;

--- a/native/app/store/AccountSlice.ts
+++ b/native/app/store/AccountSlice.ts
@@ -46,6 +46,7 @@ export type AccountSliceGetter = Parameters<StateCreator<IStore, [], [], Account
 export interface AccountSlice {
   appStartupTime: number;
   refreshing: boolean;
+  lastRefreshTime: number;
   currentListIndex: number;
 
   // The characters live in an object. This array does duplicate some of this data, but it's order
@@ -73,11 +74,13 @@ export interface AccountSlice {
   pullFromPostmaster: (updatedDestinyItem: DestinyItem) => DestinyItem;
   findDestinyItem: (itemDetails: DestinyItemIdentifier) => DestinyItem;
   setSecondarySpecial: (characterId: string, itemHash: number) => void;
+  setLastRefreshTime: () => void;
 }
 
 export const createAccountSlice: StateCreator<IStore, [], [], AccountSlice> = (set, get) => ({
   appStartupTime: 0,
   refreshing: false,
+  lastRefreshTime: 0,
   currentListIndex: 0,
 
   ggCharacters: [],
@@ -155,6 +158,9 @@ export const createAccountSlice: StateCreator<IStore, [], [], AccountSlice> = (s
         character.secondarySpecial = `${iconUrl}/${itemDefinition.ss}`;
       }
     }
+  },
+  setLastRefreshTime: () => {
+    set({ lastRefreshTime: performance.now() });
   },
 });
 

--- a/native/app/transfer/TransferLogic.ts
+++ b/native/app/transfer/TransferLogic.ts
@@ -86,6 +86,9 @@ export async function processTransfer(transferBundle: TransferBundle) {
     console.log("processTransferItem()", transferBundle);
   }
 
+  // Reset the auto refresh timer to ensure auto refresh doesn't happen mid transfer and confuse the system.
+  useGGStore.getState().setLastRefreshTime();
+
   // Is transfer complete?
   const checkedPackage = hasSuccessfullyTransferred(transferBundle);
   if (checkedPackage.completed) {


### PR DESCRIPTION
This allows any part of the app to easily reset the 35 second counter till a refresh happens. Now manual refreshes reset the counter. As does transfering items.