### PR TITLE
refactor: Optomise how page data is updated

### DIFF
--- a/native/app/bungie/Types.ts
+++ b/native/app/bungie/Types.ts
@@ -5,7 +5,6 @@ import type {
   GuardianRaceType,
   ItemType,
   DamageType,
-  UISections,
 } from "@/app/bungie/Common.ts";
 import { array, boolean, isoTimestamp, merge, number, object, optional, record, string, unknown } from "valibot";
 import type { Output } from "valibot";
@@ -435,7 +434,4 @@ export type GGCharacterUiData = {
   secondarySpecial: string;
   lastActiveCharacter: boolean;
   ggCharacterType: GGCharacterType;
-  armorPageData: UISections[];
-  generalPageData: UISections[];
-  weaponsPageData: UISections[];
 };

--- a/native/app/screens/InventoryPage.tsx
+++ b/native/app/screens/InventoryPage.tsx
@@ -1,4 +1,3 @@
-import type { GGCharacterUiData } from "@/app/bungie/Types.ts";
 import { InventoryPageEnums, type UISections } from "@/app/bungie/Common";
 import { UiCellRenderItem } from "@/app/inventory/UiRowRenderItem.tsx";
 import { useGGStore } from "@/app/store/GGStore.ts";
@@ -21,17 +20,6 @@ function calcCurrentListIndex(posX: number, PAGE_WIDTH: number) {
     }
   }
   useGGStore.getState().setCurrentListIndex(index);
-}
-
-function getData(ggCharacter: GGCharacterUiData, inventoryPage: InventoryPageEnums): UISections[] | undefined {
-  switch (inventoryPage) {
-    case InventoryPageEnums.Armor:
-      return ggCharacter.armorPageData;
-    case InventoryPageEnums.General:
-      return ggCharacter.generalPageData;
-    case InventoryPageEnums.Weapons:
-      return ggCharacter.weaponsPageData;
-  }
 }
 
 type InventoryPageProps = {
@@ -101,7 +89,18 @@ export default function InventoryPage(props: InventoryPageProps) {
   const debouncedMove = debounce(listMoved, 40);
   const debounceListIndex = debounce(calcCurrentListIndex, 40);
 
-  const mainData = useGGStore((state) => state.ggCharacters);
+  function getData(inventoryPage: InventoryPageEnums): UISections[][] | undefined {
+    switch (inventoryPage) {
+      case InventoryPageEnums.Armor:
+        return useGGStore((state) => state.ggArmor);
+      case InventoryPageEnums.General:
+        return useGGStore((state) => state.ggGeneral);
+      case InventoryPageEnums.Weapons:
+        return useGGStore((state) => state.ggWeapons);
+    }
+  }
+
+  const mainData = getData(props.inventoryPages) ?? [];
 
   return (
     <View style={rootStyles.root}>
@@ -112,7 +111,7 @@ export default function InventoryPage(props: InventoryPageProps) {
         onScroll={(e) => debounceListIndex(e.nativeEvent.contentOffset.x, HOME_WIDTH)}
         ref={pagedScrollRef}
       >
-        {mainData.map((character, index) => {
+        {mainData.map((_c, index) => {
           return (
             // biome-ignore lint/suspicious/noArrayIndexKey: <Index is unique for each page in this case>
             <View key={index} style={styles.page}>
@@ -120,7 +119,7 @@ export default function InventoryPage(props: InventoryPageProps) {
                 ref={(ref) => {
                   listRefs.current[index] = ref;
                 }}
-                data={getData(character, props.inventoryPages)}
+                data={mainData[index]}
                 renderItem={UiCellRenderItem}
                 keyExtractor={keyExtractor}
                 estimatedItemSize={pageEstimatedFlashListItemSize[index]}

--- a/native/app/store/AccountLogic.ts
+++ b/native/app/store/AccountLogic.ts
@@ -45,9 +45,6 @@ export function getCharactersAndVault(guardians: Record<string, Guardian>): GGCh
     secondarySpecial,
     lastActiveCharacter: false,
     ggCharacterType: GGCharacterType.Vault,
-    armorPageData: [],
-    generalPageData: [],
-    weaponsPageData: [],
   };
   ggCharacters.push(vaultData);
 
@@ -70,9 +67,6 @@ function addCharacterDefinition(guardianData: GuardianData): GGCharacterUiData {
     secondarySpecial: "",
     lastActiveCharacter: false,
     ggCharacterType: GGCharacterType.Guardian,
-    armorPageData: [],
-    generalPageData: [],
-    weaponsPageData: [],
   };
 
   return data;

--- a/native/app/store/AccountSlice.ts
+++ b/native/app/store/AccountSlice.ts
@@ -16,6 +16,7 @@ import {
   DestinyClass,
   ItemType,
   type DestinyItemIdentifier,
+  type UISections,
 } from "@/app/bungie/Common";
 import { findDestinyItem, getCharactersAndVault } from "@/app/store/AccountLogic.ts";
 import {
@@ -58,6 +59,9 @@ export interface AccountSlice {
   // The characters live in an object. This array does duplicate some of this data, but it's order
   // dictates
   ggCharacters: GGCharacterUiData[];
+  ggWeapons: UISections[][];
+  ggArmor: UISections[][];
+  ggGeneral: UISections[][];
 
   selectedItem: DestinyItem | null;
 
@@ -91,6 +95,9 @@ export const createAccountSlice: StateCreator<IStore, [], [], AccountSlice> = (s
   currentListIndex: 0,
 
   ggCharacters: [],
+  ggWeapons: [],
+  ggArmor: [],
+  ggGeneral: [],
 
   selectedItem: null,
 


### PR DESCRIPTION
Each inventory page is now a seperate array in the store that can be updated on its own. As opposed to a large ggCharacters object having to be updated regardless of which page changed.

Then instead of always creating a costly mutative 'create' object the checks for new data are done first. If the data changes then then mutative is used.