### PR TITLE
refactor: Move raw data outside Zustand

### DIFF
--- a/native/app/store/AccountLogic.ts
+++ b/native/app/store/AccountLogic.ts
@@ -7,8 +7,15 @@ import {
   type DestinyItem,
 } from "@/app/bungie/Types.ts";
 import { bungieUrl, GuardianClassType, type DestinyItemIdentifier } from "@/app/bungie/Common";
-import type { AccountSliceGetter } from "@/app/store/AccountSlice.ts";
-import { bucketTypeHashArray, itemsDefinition } from "@/app/store/Definitions.ts";
+import {
+  bucketTypeHashArray,
+  consumables,
+  generalVault,
+  guardians,
+  itemsDefinition,
+  lostItems,
+  mods,
+} from "@/app/store/Definitions.ts";
 import {
   GLOBAL_CONSUMABLES_CHARACTER_ID,
   GLOBAL_LOST_ITEMS_CHARACTER_ID,
@@ -75,7 +82,7 @@ function addCharacterDefinition(guardianData: GuardianData): GGCharacterUiData {
 // These are the fewest arguments possible. itemInstanceId would be enough for all instanced items. But for non
 // instanced the characterId and itemHash are needed. Because you could have a non instanced item such as upgrade
 // materials in the lost items of two different characters. So the characterId is needed to find the correct item.
-export function findDestinyItem(get: AccountSliceGetter, itemIdentifier: DestinyItemIdentifier): DestinyItem {
+export function findDestinyItem(itemIdentifier: DestinyItemIdentifier): DestinyItem {
   const itemDefinition = itemsDefinition[itemIdentifier.itemHash];
   if (!itemDefinition) {
     throw new Error("No itemDefinition found");
@@ -86,8 +93,7 @@ export function findDestinyItem(get: AccountSliceGetter, itemIdentifier: Destiny
 
     if (defaultBucket) {
       if (itemIdentifier.characterId === VAULT_CHARACTER_ID) {
-        const vault = get().generalVault;
-        const vaultSectionInventory = vault[defaultBucket];
+        const vaultSectionInventory = generalVault[defaultBucket];
         if (vaultSectionInventory) {
           try {
             const item = findDestinyItemInArray(vaultSectionInventory, itemIdentifier);
@@ -97,7 +103,6 @@ export function findDestinyItem(get: AccountSliceGetter, itemIdentifier: Destiny
           }
         }
       } else if (itemIdentifier.characterId === GLOBAL_MODS_CHARACTER_ID) {
-        const mods = get().mods;
         if (mods) {
           try {
             const item = findDestinyItemInArray(mods, itemIdentifier);
@@ -107,7 +112,6 @@ export function findDestinyItem(get: AccountSliceGetter, itemIdentifier: Destiny
           }
         }
       } else if (itemIdentifier.characterId === GLOBAL_CONSUMABLES_CHARACTER_ID) {
-        const consumables = get().consumables;
         if (consumables) {
           try {
             const item = findDestinyItemInArray(consumables, itemIdentifier);
@@ -117,7 +121,6 @@ export function findDestinyItem(get: AccountSliceGetter, itemIdentifier: Destiny
           }
         }
       } else if (itemIdentifier.characterId === GLOBAL_LOST_ITEMS_CHARACTER_ID) {
-        const lostItems = get().lostItems;
         if (lostItems) {
           try {
             const item = findDestinyItemInArray(lostItems, itemIdentifier);
@@ -127,7 +130,6 @@ export function findDestinyItem(get: AccountSliceGetter, itemIdentifier: Destiny
           }
         }
       } else {
-        const guardians = get().guardians;
         const section = guardians[itemIdentifier.characterId]?.items[defaultBucket];
 
         if (section) {
@@ -160,23 +162,20 @@ export function findDestinyItem(get: AccountSliceGetter, itemIdentifier: Destiny
   throw new Error("No DestinyItem found");
 }
 
-export function findMaxQuantityToTransfer(get: AccountSliceGetter, destinyItem: DestinyItem): number {
+export function findMaxQuantityToTransfer(destinyItem: DestinyItem): number {
   switch (destinyItem.characterId) {
     case GLOBAL_MODS_CHARACTER_ID: {
-      const mods = get().mods;
       const filteredItems = mods.filter((item) => item.itemHash === destinyItem.itemHash);
       const totalStackedQuantity = filteredItems.reduce((total, item) => total + item.quantity, 0);
       return totalStackedQuantity;
     }
     case GLOBAL_CONSUMABLES_CHARACTER_ID: {
-      const consumables = get().consumables;
       const filteredItems = consumables.filter((item) => item.itemHash === destinyItem.itemHash);
       const totalStackedQuantity = filteredItems.reduce((total, item) => total + item.quantity, 0);
       return totalStackedQuantity;
     }
     case VAULT_CHARACTER_ID: {
-      const vault = get().generalVault;
-      const vaultSectionInventory = vault[destinyItem.bucketHash];
+      const vaultSectionInventory = generalVault[destinyItem.bucketHash];
       if (!vaultSectionInventory) {
         console.error("Failed to find section inventory");
         return 1;

--- a/native/app/store/Definitions.ts
+++ b/native/app/store/Definitions.ts
@@ -1,4 +1,4 @@
-import type { ProfileData } from "@/app/bungie/Types.ts";
+import type { DestinyItem, Guardian, ProfileData } from "@/app/bungie/Types.ts";
 import type { SingleItemDefinition } from "@/app/store/Types.ts";
 
 export type ItemsDefinition = Record<string, SingleItemDefinition>;
@@ -11,9 +11,14 @@ export let stackUniqueLabel: string[];
 export let PlugCategoryIdentifier: string[];
 
 export let rawProfileData: ProfileData | null;
+export let lostItems: DestinyItem[] = [];
+export let consumables: DestinyItem[] = [];
+export let mods: DestinyItem[] = [];
+export let generalVault: Record<number, DestinyItem[]> = {};
+export let guardians: Record<string, Guardian> = {};
 
-export function setItemDefinition(itemDefinition: ItemsDefinition) {
-  itemsDefinition = itemDefinition;
+export function setItemDefinition(newItemsDefinition: ItemsDefinition) {
+  itemsDefinition = newItemsDefinition;
 }
 
 export function setBucketTypeHashArray(bucketTypeHashDefinition: number[]) {
@@ -38,4 +43,24 @@ export function setRawProfileData(profileData: ProfileData) {
 
 export function setPlugCategoryIdentifier(plugCategoryIdentifier: string[]) {
   PlugCategoryIdentifier = plugCategoryIdentifier;
+}
+
+export function setLostItems(newLostItems: DestinyItem[]) {
+  lostItems = newLostItems;
+}
+
+export function setConsumables(newConsumables: DestinyItem[]) {
+  consumables = newConsumables;
+}
+
+export function setMods(newMods: DestinyItem[]) {
+  mods = newMods;
+}
+
+export function setGeneralVault(newGeneralVault: Record<number, DestinyItem[]>) {
+  generalVault = newGeneralVault;
+}
+
+export function setGuardians(newGuardians: Record<string, Guardian>) {
+  guardians = newGuardians;
 }

--- a/native/app/store/UIDataSlice.ts
+++ b/native/app/store/UIDataSlice.ts
@@ -1,4 +1,5 @@
 import { SectionBuckets, equipSectionBuckets } from "@/app/bungie/Common";
+import { consumables, mods } from "@/app/store/Definitions.ts";
 
 import type { IStore } from "@/app/store/GGStore.ts";
 import {
@@ -50,13 +51,13 @@ function getVaultSpacerSize(get: UIDataSliceGetter, bucket: SectionBuckets): num
   }
 
   if (bucket === SectionBuckets.Consumables) {
-    const totalConsumables = get().consumables.length;
+    const totalConsumables = consumables.length;
     const totalRows = Math.ceil(totalConsumables / 5);
     return ICON_SIZE * totalRows + ICON_VAULT_MARGIN * (totalRows - 1);
   }
 
   if (bucket === SectionBuckets.Mods) {
-    const totalMods = get().mods.length;
+    const totalMods = mods.length;
     const totalRows = Math.ceil(totalMods / 5);
     return ICON_SIZE * totalRows + ICON_VAULT_MARGIN * (totalRows - 1);
   }

--- a/native/app/transfer/TransferLogic.ts
+++ b/native/app/transfer/TransferLogic.ts
@@ -8,7 +8,7 @@ import {
   DestinyClass,
   ItemType,
 } from "@/app/bungie/Common";
-import { itemsDefinition } from "@/app/store/Definitions.ts";
+import { guardians, itemsDefinition } from "@/app/store/Definitions.ts";
 import { useGGStore } from "@/app/store/GGStore.ts";
 import { GLOBAL_INVENTORY_NAMES, VAULT_CHARACTER_ID } from "@/app/utilities/Constants.ts";
 import { bitmaskContains } from "@/app/utilities/Helpers.ts";
@@ -178,8 +178,7 @@ async function equipItemLogic(transferBundle: TransferBundle, transferItem: Tran
     // is there an unequip item for the other exotic?
     const itemToUnequip = returnBlockingExotic(transferItem.destinyItem);
     if (itemToUnequip) {
-      const sectionItems =
-        useGGStore.getState().guardians[itemToUnequip.characterId]?.items[itemToUnequip.bucketHash]?.inventory;
+      const sectionItems = guardians[itemToUnequip.characterId]?.items[itemToUnequip.bucketHash]?.inventory;
 
       if (sectionItems && sectionItems.length > 0) {
         const unequipItem = getUnequipItem(sectionItems, false);
@@ -260,7 +259,7 @@ function returnBlockingExotic(destinyItem: DestinyItem): DestinyItem | null {
   }
 
   const characterId = destinyItem.characterId;
-  const guardiansItems = useGGStore.getState().guardians[characterId]?.items;
+  const guardiansItems = guardians[characterId]?.items;
 
   if (!guardiansItems) {
     return null;
@@ -296,8 +295,7 @@ function unequipItemLogic(transferBundle: TransferBundle, transferItem: Transfer
   try {
     // Bail if the section has no items
     const sectionItems =
-      useGGStore.getState().guardians[transferItem.destinyItem.characterId]?.items[transferItem.destinyItem.bucketHash]
-        ?.inventory;
+      guardians[transferItem.destinyItem.characterId]?.items[transferItem.destinyItem.bucketHash]?.inventory;
     if (!sectionItems || sectionItems.length === 0) {
       console.error("Failed to unquip item as section has no items");
       const name = itemsDefinition[transferItem.destinyItem.itemHash]?.n;
@@ -328,8 +326,7 @@ function unequipItemLogic(transferBundle: TransferBundle, transferItem: Transfer
     unequipItem = getUnequipItem(sectionItems, true);
     // Can an exotic be equipped? If the currently equipped item is an exotic there is no issue
     const currentEquippedItem =
-      useGGStore.getState().guardians[transferItem.destinyItem.characterId]?.items[transferItem.destinyItem.bucketHash]
-        ?.equipped;
+      guardians[transferItem.destinyItem.characterId]?.items[transferItem.destinyItem.bucketHash]?.equipped;
 
     if (currentEquippedItem?.tierType === TierType.Exotic && unequipItem) {
       const name = itemsDefinition[unequipItem.itemHash]?.n;
@@ -366,7 +363,7 @@ function hasBlockingExotic(destinyItem: DestinyItem): boolean {
   }
 
   const characterId = destinyItem.characterId;
-  const guardiansItems = useGGStore.getState().guardians[characterId]?.items;
+  const guardiansItems = guardians[characterId]?.items;
 
   if (!guardiansItems) {
     return false;
@@ -624,7 +621,6 @@ async function pullFromPostmaster(transferItem: TransferItem): Promise<[JSON, De
 }
 
 function _getUnequipItem(itemToUnequip: DestinyItem): DestinyItem {
-  const guardians = useGGStore.getState().guardians;
   // DestinyItem unequipItem
   let unequipItem: DestinyItem;
 


### PR DESCRIPTION
The raw inventory data doesn't need to live inside Zustand where setting it can be slow. Only the UI data created from it should be in Zustand where it can be listened too.