### PR TITLE
refactor: Update the bottom sheet

### DIFF
--- a/native/app/App.tsx
+++ b/native/app/App.tsx
@@ -6,10 +6,8 @@ import { useEffect, useRef } from "react";
 import { getBungieManifest, getFullProfile } from "@/app/bungie/BungieApi.ts";
 import MainDrawer from "@/app/UI/MainDrawer.tsx";
 import Login from "@/app/UI/Login.tsx";
-import { Platform, useWindowDimensions } from "react-native";
-import BottomSheet from "@/app/inventory/pages/BottomSheet.tsx";
+import { useWindowDimensions } from "react-native";
 import { enableFreeze } from "react-native-screens";
-import type { DestinyItem } from "@/app/inventory/logic/Types.ts";
 import { getCustomManifest } from "@/app/utilities/Helpers.ts";
 import { object, parse, string } from "valibot";
 import Toast from "react-native-toast-message";
@@ -46,7 +44,6 @@ init();
 type RootStackParamList = {
   Login: undefined;
   Root: undefined;
-  BottomSheet: { item: DestinyItem };
 };
 
 const RootStack = createStackNavigator<RootStackParamList>();
@@ -121,17 +118,6 @@ function App() {
           </RootStack.Group>
           <RootStack.Group screenOptions={{ presentation: "modal", gestureEnabled: false, headerShown: false }}>
             <RootStack.Screen name="Login" component={Login} options={{ title: "Login" }} />
-          </RootStack.Group>
-          <RootStack.Group
-            screenOptions={{
-              presentation: Platform.OS === "ios" ? "modal" : "transparentModal",
-              headerShown: false,
-              cardStyle: {
-                backgroundColor: "transparent",
-              },
-            }}
-          >
-            <RootStack.Screen name="BottomSheet" component={BottomSheet} />
           </RootStack.Group>
         </RootStack.Navigator>
         <Toast />

--- a/native/app/UI/MainDrawer.tsx
+++ b/native/app/UI/MainDrawer.tsx
@@ -1,11 +1,8 @@
 import { getFullProfile } from "@/app/bungie/BungieApi.ts";
-import type { DestinyItem } from "@/app/inventory/logic/Types.ts";
 import InventoryHeader from "@/app/inventory/pages/InventoryHeader.tsx";
 import InventoryPages from "@/app/inventory/pages/InventoryPages.tsx";
 import { useGGStore } from "@/app/store/GGStore.ts";
 import { type DrawerContentComponentProps, createDrawerNavigator } from "@react-navigation/drawer";
-import { useNavigation } from "@react-navigation/native";
-import { useEffect } from "react";
 import { Platform, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { getGuardianClassType } from "@/app/utilities/Helpers.ts";
@@ -189,18 +186,6 @@ export default function MainDrawer() {
   const ggGuardians = useGGStore((state) => state.ggCharacters);
   const currentListIndex = useGGStore((state) => state.currentListIndex);
   const guardianClassType = getGuardianClassType(ggGuardians[currentListIndex]?.guardianClassType);
-  const navigator = useNavigation();
-  const selectedItem = useGGStore((state) => state.selectedItem);
-
-  function activateSheet(item: DestinyItem) {
-    navigator.navigate("BottomSheet", { item });
-  }
-
-  useEffect(() => {
-    if (selectedItem) {
-      activateSheet(selectedItem);
-    }
-  }, [selectedItem, activateSheet]);
 
   return (
     <Drawer.Navigator

--- a/native/app/inventory/pages/InventoryPages.tsx
+++ b/native/app/inventory/pages/InventoryPages.tsx
@@ -4,7 +4,8 @@ import GeneralPage from "@/app/inventory/pages/GeneralPage.tsx";
 import React from "react";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { Image } from "expo-image";
-import { StyleSheet } from "react-native";
+import { StyleSheet, View } from "react-native";
+import BottomSheet from "@/app/inventory/pages/BottomSheet.tsx";
 
 const WEAPONS_TAB_ICON = require("../../../images/weapons_tab.webp");
 const ARMOR_TAB_ICON = require("../../../images/armor_tab.webp");
@@ -14,76 +15,79 @@ const Tab = createBottomTabNavigator();
 
 function InventoryPages() {
   return (
-    <Tab.Navigator
-      detachInactiveScreens={true}
-      screenOptions={({ route }) => ({
-        tabBarIcon: ({ focused }) => {
-          switch (route.name) {
-            case "tab-weapons":
-              return (
-                <Image
-                  source={WEAPONS_TAB_ICON}
-                  cachePolicy="memory"
-                  style={{ width: 20, height: 20, opacity: focused ? 1 : 0.4 }}
-                />
-              );
-            case "tab-armor":
-              return (
-                <Image
-                  source={ARMOR_TAB_ICON}
-                  cachePolicy="memory"
-                  style={{ width: 20, height: 20, opacity: focused ? 1 : 0.4 }}
-                />
-              );
-            case "tab-inventory":
-              return (
-                <Image
-                  source={GENERAL_TAB_ICON}
-                  cachePolicy="memory"
-                  style={{ width: 20, height: 20, opacity: focused ? 1 : 0.4 }}
-                />
-              );
-          }
-        },
-        tabBarActiveTintColor: "white",
-        tabBarInactiveTintColor: "gray",
-        tabBarStyle: {
-          borderTopColor: "grey",
-          borderTopWidth: StyleSheet.hairlineWidth,
-        },
-      })}
-    >
-      <Tab.Screen
-        name="tab-weapons"
-        options={{
-          tabBarLabel: "Weapons",
-          headerStyle: {
-            height: 0,
+    <View style={{ flex: 1 }}>
+      <Tab.Navigator
+        detachInactiveScreens={true}
+        screenOptions={({ route }) => ({
+          tabBarIcon: ({ focused }) => {
+            switch (route.name) {
+              case "tab-weapons":
+                return (
+                  <Image
+                    source={WEAPONS_TAB_ICON}
+                    cachePolicy="memory"
+                    style={{ width: 20, height: 20, opacity: focused ? 1 : 0.4 }}
+                  />
+                );
+              case "tab-armor":
+                return (
+                  <Image
+                    source={ARMOR_TAB_ICON}
+                    cachePolicy="memory"
+                    style={{ width: 20, height: 20, opacity: focused ? 1 : 0.4 }}
+                  />
+                );
+              case "tab-inventory":
+                return (
+                  <Image
+                    source={GENERAL_TAB_ICON}
+                    cachePolicy="memory"
+                    style={{ width: 20, height: 20, opacity: focused ? 1 : 0.4 }}
+                  />
+                );
+            }
           },
-        }}
-        component={WeaponsPage}
-      />
-      <Tab.Screen
-        name="tab-armor"
-        options={{
-          tabBarLabel: "Armor",
-          headerStyle: {
-            height: 0,
+          tabBarActiveTintColor: "white",
+          tabBarInactiveTintColor: "gray",
+          tabBarStyle: {
+            borderTopColor: "grey",
+            borderTopWidth: StyleSheet.hairlineWidth,
           },
-        }}
-        component={ArmorPage}
-      />
-      <Tab.Screen
-        name="tab-inventory"
-        options={{
-          tabBarLabel: "Inventory",
-          headerStyle: {
-            height: 0,
-          },
-        }}
-        component={GeneralPage}
-      />
-    </Tab.Navigator>
+        })}
+      >
+        <Tab.Screen
+          name="tab-weapons"
+          options={{
+            tabBarLabel: "Weapons",
+            headerStyle: {
+              height: 0,
+            },
+          }}
+          component={WeaponsPage}
+        />
+        <Tab.Screen
+          name="tab-armor"
+          options={{
+            tabBarLabel: "Armor",
+            headerStyle: {
+              height: 0,
+            },
+          }}
+          component={ArmorPage}
+        />
+        <Tab.Screen
+          name="tab-inventory"
+          options={{
+            tabBarLabel: "Inventory",
+            headerStyle: {
+              height: 0,
+            },
+          }}
+          component={GeneralPage}
+        />
+      </Tab.Navigator>
+      <BottomSheet />
+    </View>
   );
 }
 

--- a/native/app/inventory/pages/TransferEquipButtons.tsx
+++ b/native/app/inventory/pages/TransferEquipButtons.tsx
@@ -6,9 +6,7 @@ import {
   GLOBAL_MODS_CHARACTER_ID,
   VAULT_CHARACTER_ID,
 } from "@/app/utilities/Constants.ts";
-import { View, StyleSheet, Text } from "react-native";
-import { Gesture, GestureDetector, GestureHandlerRootView } from "react-native-gesture-handler";
-import { runOnJS } from "react-native-reanimated";
+import { View, StyleSheet, Text, TouchableOpacity } from "react-native";
 import { Image } from "expo-image";
 import { getGuardianRaceType, getGuardianClassType } from "@/app/utilities/Helpers.ts";
 import { GLOBAL_SPACE_EMBLEM } from "@/app/inventory/logic/Constants.ts";
@@ -95,47 +93,47 @@ export default function TransferEquipButtons(props: TransferEquipButtonsProps) {
       props.destinyItem.def.recoveryBucketHash === SectionBuckets.Mods
         ? GLOBAL_MODS_CHARACTER_ID
         : GLOBAL_CONSUMABLES_CHARACTER_ID;
-    const transferTap = Gesture.Tap().onBegin(() => {
-      runOnJS(props.startTransfer)(ggCharacterId, false);
-      runOnJS(props.close)();
-    });
+
     const globalButton = (
-      <GestureHandlerRootView style={{ flexDirection: "row", gap: 5 }}>
-        <GestureDetector gesture={transferTap}>
+      <TouchableOpacity
+        onPress={() => {
+          props.startTransfer(ggCharacterId, false);
+          props.close();
+        }}
+      >
+        <View
+          style={{
+            width: transferWidth,
+            height: transferHeight,
+            borderRadius,
+            overflow: "hidden",
+          }}
+        >
           <View
             style={{
-              width: transferWidth,
-              height: transferHeight,
-              borderRadius,
+              width: originalWidth,
               overflow: "hidden",
+              transformOrigin: "top left",
+              transform: [{ scale: scale }],
             }}
           >
-            <View
-              style={{
-                width: originalWidth,
-                overflow: "hidden",
-                transformOrigin: "top left",
-                transform: [{ scale: scale }],
-              }}
-            >
-              <Image source={GLOBAL_SPACE_EMBLEM} cachePolicy={"memory"} style={{ width: 474, height: 96 }} />
-              <Text style={styles.InventoryName}>{"Inventory"}</Text>
-            </View>
-            <View
-              style={{
-                position: "absolute",
-                top: 0,
-                bottom: 0,
-                left: 0,
-                right: 0,
-                borderRadius,
-                borderWidth: 1,
-                borderColor: "grey",
-              }}
-            />
+            <Image source={GLOBAL_SPACE_EMBLEM} cachePolicy={"memory"} style={{ width: 474, height: 96 }} />
+            <Text style={styles.InventoryName}>{"Inventory"}</Text>
           </View>
-        </GestureDetector>
-      </GestureHandlerRootView>
+          <View
+            style={{
+              position: "absolute",
+              top: 0,
+              bottom: 0,
+              left: 0,
+              right: 0,
+              borderRadius,
+              borderWidth: 1,
+              borderColor: "grey",
+            }}
+          />
+        </View>
+      </TouchableOpacity>
     );
     return (
       <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 5, padding: 15 }}>
@@ -203,24 +201,15 @@ export default function TransferEquipButtons(props: TransferEquipButtonsProps) {
       continue;
     }
 
-    const transferTap = Gesture.Tap().onBegin(() => {
-      if (isTransferDisabled) {
-        return;
-      }
-      runOnJS(props.startTransfer)(ggCharacter.characterId, false);
-      runOnJS(props.close)();
-    });
-    const transferAndEquipTap = Gesture.Tap().onBegin(() => {
-      if (isEquipDisabled) {
-        return;
-      }
-      runOnJS(props.startTransfer)(ggCharacter.characterId, true);
-      runOnJS(props.close)();
-    });
-
     rectangles.push(
-      <GestureHandlerRootView key={ggCharacter.characterId} style={{ flexDirection: "row", gap: 5 }}>
-        <GestureDetector gesture={transferTap}>
+      <View key={ggCharacter.characterId} style={{ flexDirection: "row", gap: 5 }}>
+        <TouchableOpacity
+          disabled={isTransferDisabled}
+          onPress={() => {
+            props.startTransfer(ggCharacter.characterId, false);
+            props.close();
+          }}
+        >
           <View
             style={{
               width: transferWidth,
@@ -258,8 +247,14 @@ export default function TransferEquipButtons(props: TransferEquipButtonsProps) {
               }}
             />
           </View>
-        </GestureDetector>
-        <GestureDetector gesture={transferAndEquipTap}>
+        </TouchableOpacity>
+        <TouchableOpacity
+          disabled={isEquipDisabled}
+          onPress={() => {
+            props.startTransfer(ggCharacter.characterId, true);
+            props.close();
+          }}
+        >
           <View
             style={{
               width: transferHeight,
@@ -291,8 +286,8 @@ export default function TransferEquipButtons(props: TransferEquipButtonsProps) {
               }}
             />
           </View>
-        </GestureDetector>
-      </GestureHandlerRootView>,
+        </TouchableOpacity>
+      </View>,
     );
   }
 

--- a/native/app/stats/Stats.tsx
+++ b/native/app/stats/Stats.tsx
@@ -4,6 +4,8 @@ import { createSockets } from "@/app/inventory/logic/Sockets.ts";
 import ReusablePlugs from "@/app/stats/ReusablePlugs";
 import { createWeaponStats } from "@/app/stats/Logic.ts";
 import StatBars from "@/app/stats/StatBars.tsx";
+import { useMemo } from "react";
+import React from "react";
 
 const _styles = StyleSheet.create({
   container: {
@@ -18,8 +20,8 @@ type StatsProps = {
   destinyItem: DestinyItem;
 };
 
-export default function Stats(props: StatsProps) {
-  const sockets = createSockets(props.destinyItem);
+function Stats(props: StatsProps) {
+  const sockets = useMemo(() => createSockets(props.destinyItem), [props.destinyItem]);
   if (!sockets) {
     return null;
   }
@@ -34,3 +36,5 @@ export default function Stats(props: StatsProps) {
     </View>
   );
 }
+
+export default React.memo(Stats);


### PR DESCRIPTION
This change stops the entire view being a full 'modal'. A bottom sheet should never have been this type of modal and it caused touch to be unresponsive on iOS for a second after the sheet slide off.

Touch events would also fire on button in a scrollview when they were touched, but the view was scrolled. This is now fixed.

Finally you can pan to close the bottom sheet. However if you have scrolled down, then you have to scroll up, lift your finger, then pan again. It's annoying but will have to be fixed later.

I tried alternative bottom-sheets and they either had different issues or didn't work for the web export.