### PR TITLE
refactor: Start to use branded types

### DIFF
--- a/native/app/core/GetProfile.ts
+++ b/native/app/core/GetProfile.ts
@@ -4,6 +4,7 @@
 // -------------------------------
 
 import { bungieResponseSchema } from "@/app/core/ApiResponse.ts";
+import type { Branded } from "@/app/utilities/Helpers.ts";
 import {
   array,
   boolean,
@@ -68,7 +69,15 @@ export const ItemSchema = object({
   versionNumber: optional(number()),
 });
 
-export type DestinyItemBase = Output<typeof ItemSchema>;
+export type ItemHash = Branded<number, "ItemHash">;
+export type ItemInstanceId = Branded<string, "ItemInstanceId">;
+
+type RawDestinyItemBase = Output<typeof ItemSchema>;
+export type DestinyItemBase = Omit<RawDestinyItemBase, "itemHash" | "itemInstanceId" | "overrideStyleItemHash"> & {
+  itemHash: ItemHash;
+  itemInstanceId?: ItemInstanceId;
+  overrideStyleItemHash?: ItemHash;
+};
 
 export const GuardiansSchema = object({
   baseCharacterLevel: number(),

--- a/native/app/inventory/cells/DestinyCell2.tsx
+++ b/native/app/inventory/cells/DestinyCell2.tsx
@@ -11,6 +11,7 @@ import React from "react";
 import { StyleSheet, Text, View, TouchableOpacity } from "react-native";
 import { CRAFTED_OVERLAY, DEFAULT_OVERLAP_COLOR } from "@/app/inventory/logic/Constants.ts";
 import { useNavigation } from "@react-navigation/native";
+import type { ItemHash, ItemInstanceId } from "@/app/core/GetProfile.ts";
 
 const common = StyleSheet.create({
   quantity: {
@@ -111,8 +112,8 @@ const styles = StyleSheet.create({
 
 type DestinyCellProps = {
   readonly characterId: string;
-  readonly itemHash: number;
-  readonly itemInstanceId: string | undefined;
+  readonly itemHash: ItemHash;
+  readonly itemInstanceId: ItemInstanceId | undefined;
   readonly bucketHash: number;
   readonly icon: string;
   readonly calculatedWaterMark: string;

--- a/native/app/inventory/logic/Helpers.ts
+++ b/native/app/inventory/logic/Helpers.ts
@@ -1,6 +1,7 @@
 import { SectionBuckets, StatType } from "@/app/bungie/Enums.ts";
 import type { DestinyIconData } from "@/app/inventory/logic/Types.ts";
 import { iconUrl } from "@/app/core/ApiResponse.ts";
+import type { ItemHash, ItemInstanceId } from "@/app/core/GetProfile.ts";
 
 export enum InventoryPageEnums {
   Unknown = 0,
@@ -177,8 +178,8 @@ export type UISections =
 
 export type DestinyItemIdentifier = {
   characterId: string;
-  itemHash: number;
-  itemInstanceId: string | undefined;
+  itemHash: ItemHash;
+  itemInstanceId: ItemInstanceId | undefined;
   bucketHash: number;
 };
 

--- a/native/app/inventory/logic/Sockets.ts
+++ b/native/app/inventory/logic/Sockets.ts
@@ -1,5 +1,5 @@
 import type { DestinyItem, DestinyItemDefinition } from "@/app/inventory/logic/Types.ts";
-import type { PlugSet } from "@/app/core/GetProfile.ts";
+import type { ItemHash, PlugSet } from "@/app/core/GetProfile.ts";
 import {
   DestinySocketCategoryDefinition,
   ReusablePlugSetHash,
@@ -80,7 +80,7 @@ export type SocketEntry = {
   // modType: ModType; // default is.Normal
 
   // extending that type? But right now it's not been needed.
-  itemHash: number;
+  itemHash: ItemHash;
   plugSources: number; // This is a bitmask
 
   reusablePlugSocketIndex: number | null;
@@ -91,7 +91,7 @@ export type SocketEntry = {
 
   socketIndex: number | null;
   socketTypeHash: number | null;
-  singleInitialItemHash: number | null;
+  singleInitialItemHash: ItemHash | null;
 
   reusablePlugSetHash: number | null;
 
@@ -171,7 +171,7 @@ export function createSockets(destinyItem: DestinyItem): Sockets | null {
 
 const ExpandedSocketsCache = new Map<number, Sockets>();
 
-function expandAndCreateSockets(itemHash: number): Sockets | null {
+function expandAndCreateSockets(itemHash: ItemHash): Sockets | null {
   if (ExpandedSocketsCache.has(itemHash)) {
     const sockets = ExpandedSocketsCache.get(itemHash)!;
     // Deep clone the object to prevent mutation
@@ -211,7 +211,7 @@ function expandAndCreateSockets(itemHash: number): Sockets | null {
     }
 
     const se: SocketEntry = {
-      itemHash: 0,
+      itemHash: 0 as ItemHash,
       isVisible: false,
       isEnabled: false,
       iconType: IconType.Plug,
@@ -297,7 +297,7 @@ function updateSocketEntriesWithLiveData(sockets: Sockets, destinyItem: DestinyI
   liveSockets.sockets.forEach((socket, index) => {
     const se = sockets.socketEntries[index];
     if (se) {
-      se.itemHash = socket.plugHash ?? 0;
+      se.itemHash = (socket.plugHash ?? 0) as ItemHash;
       se.isVisible = socket.isVisible;
       se.isEnabled = socket.isEnabled;
     }
@@ -410,7 +410,7 @@ function makeSocketEntryColumn(
         socketToAppend = socketEntry;
       } else {
         const s: SocketEntry = {
-          itemHash: 0,
+          itemHash: 0 as ItemHash,
           iconType: IconType.Plug,
           plugSourcesAsEnums: [],
           plugSources: 0,
@@ -423,7 +423,7 @@ function makeSocketEntryColumn(
           reusablePlugSetHash: null,
           reusablePlugSocketIndex: null,
         };
-        s.itemHash = plugItemHash;
+        s.itemHash = plugItemHash as ItemHash;
         socketToAppend = s;
       }
 

--- a/native/app/inventory/logic/Types.ts
+++ b/native/app/inventory/logic/Types.ts
@@ -10,7 +10,7 @@ import {
   type ItemType,
   type TierType,
 } from "@/app/bungie/Enums.ts";
-import type { DestinyItemBase, GuardianData } from "@/app/core/GetProfile.ts";
+import type { DestinyItemBase, GuardianData, ItemHash, ItemInstanceId } from "@/app/core/GetProfile.ts";
 import { number, object, string } from "valibot";
 import type { Output } from "valibot";
 
@@ -139,8 +139,8 @@ export const characterBuckets = [
 ];
 
 export type DestinyIconData = {
-  itemHash: number;
-  itemInstanceId: string | undefined;
+  itemHash: ItemHash;
+  itemInstanceId: ItemInstanceId | undefined;
   characterId: string;
   icon: string;
   damageTypeIconUri: number | null;
@@ -156,8 +156,8 @@ export type DestinyIconData = {
 };
 
 export const DestinyIconDataEmpty: DestinyIconData = {
-  itemHash: 0,
-  itemInstanceId: "",
+  itemHash: 0 as ItemHash,
+  itemInstanceId: "" as ItemInstanceId,
   characterId: "",
   icon: "",
   damageTypeIconUri: null,

--- a/native/app/store/Definitions.ts
+++ b/native/app/store/Definitions.ts
@@ -7,7 +7,7 @@ import type {
   StatGroupDefinition,
   StatDefinition,
 } from "@/app/core/BungieDefinitions";
-import type { ProfileData } from "@/app/core/GetProfile.ts";
+import type { ItemHash, ProfileData } from "@/app/core/GetProfile.ts";
 
 export type ItemsDefinition = Record<string, MiniSingleItemDefinition>;
 
@@ -25,7 +25,7 @@ export let InsertionMaterialRequirementHash: number[];
 export let PlugCategoryHash: number[];
 export let PlugCategoryIdentifier: string[];
 export let ReusablePlugSetHash: number[];
-export let SingleInitialItemHash: number[];
+export let SingleInitialItemHash: ItemHash[];
 export let SocketCategories: MiniSocketCategoryItems; // These strings are JSON objects
 export let SocketCategoryHash: number[];
 export let SocketEntries: MiniSocketEntryItems;
@@ -108,7 +108,7 @@ export function setReusablePlugSetHash(reusablePlugSetHashDefinition: number[]) 
   ReusablePlugSetHash = reusablePlugSetHashDefinition;
 }
 
-export function setSingleInitialItemHash(singleInitialItemHashDefinition: number[]) {
+export function setSingleInitialItemHash(singleInitialItemHashDefinition: ItemHash[]) {
   SingleInitialItemHash = singleInitialItemHashDefinition;
 }
 

--- a/native/app/store/DefinitionsSlice.ts
+++ b/native/app/store/DefinitionsSlice.ts
@@ -54,6 +54,7 @@ import {
 } from "@/app/core/BungieDefinitions.ts";
 import { bungieUrl, type BungieManifest } from "@/app/core/ApiResponse.ts";
 import { deepEqual } from "fast-equals";
+import type { ItemHash } from "@/app/core/GetProfile.ts";
 
 export type DefinitionsSliceSetter = Parameters<StateCreator<IStore, [], [], DefinitionsSlice>>[0];
 export type DefinitionsSliceGetter = Parameters<StateCreator<IStore, [], [], DefinitionsSlice>>[1];
@@ -288,7 +289,7 @@ function parseAndSet(itemDefinition: ItemResponse) {
   setPlugCategoryHash(itemDefinition.helpers.PlugCategoryHash);
   setPlugCategoryIdentifier(itemDefinition.helpers.PlugCategoryIdentifier);
   setReusablePlugSetHash(itemDefinition.helpers.ReusablePlugSetHash);
-  setSingleInitialItemHash(itemDefinition.helpers.SingleInitialItemHash);
+  setSingleInitialItemHash(itemDefinition.helpers.SingleInitialItemHash as ItemHash[]);
   setSocketCategories(itemDefinition.helpers.SocketCategories);
   setSocketCategoryHash(itemDefinition.helpers.SocketCategoryHash);
   setSocketEntries(itemDefinition.helpers.SocketEntries);

--- a/native/app/utilities/Helpers.ts
+++ b/native/app/utilities/Helpers.ts
@@ -1,6 +1,10 @@
 import type { GuardianClassType } from "@/app/bungie/Enums.ts";
 import type { DestinyItemSort } from "@/app/inventory/logic/Types.ts";
 
+declare const __brand: unique symbol;
+type Brand<B> = { [__brand]: B };
+export type Branded<T, B> = T & Brand<B>;
+
 // biome-ignore lint/complexity/noBannedTypes: <explanation>
 export const debounce = (func: Function, delay = 0) => {
   let timeoutId: string | number | NodeJS.Timeout | undefined;


### PR DESCRIPTION
This starts for now with itemHash and itemInstanceId. It seems a bit messy so maybe there is a more elegant way to add this in.
The mess is comming from the valibot types that don't have an obvious way to support custom typescript types.