### PR TITLE
chore: Add packageManager property to fix dependabot

### DIFF
--- a/native/package.json
+++ b/native/package.json
@@ -71,5 +71,6 @@
   "main": "app/index.js",
   "name": "native_gg",
   "version": "1.0.0",
+  "packageManager": "pnpm@9.1.4",
   "private": true
 }


### PR DESCRIPTION
Dependabot is using Pnpm 8.x instead of 9.x which results in a huge diff as it rewrites the entire lock file to the old 6.0 format.