### PR TITLE
fix: Stop list items jumping on first render

### DIFF
--- a/native/app/inventory/pages/ArmorPage.tsx
+++ b/native/app/inventory/pages/ArmorPage.tsx
@@ -3,5 +3,7 @@ import InventoryPage from "@/app/inventory/pages/InventoryPage.tsx";
 
 export default function ArmorPage() {
   "use memo";
-  return <InventoryPage inventoryPages={InventoryPageEnums.Armor} />;
+  return (
+    <InventoryPage inventoryPages={InventoryPageEnums.Armor} pageEstimatedFlashListItemSize={[150, 150, 150, 92]} />
+  );
 }

--- a/native/app/inventory/pages/GeneralPage.tsx
+++ b/native/app/inventory/pages/GeneralPage.tsx
@@ -3,5 +3,7 @@ import InventoryPage from "@/app/inventory/pages/InventoryPage.tsx";
 
 export default function GeneralPage() {
   "use memo";
-  return <InventoryPage inventoryPages={InventoryPageEnums.General} />;
+  return (
+    <InventoryPage inventoryPages={InventoryPageEnums.General} pageEstimatedFlashListItemSize={[82, 82, 82, 200]} />
+  );
 }

--- a/native/app/inventory/pages/InventoryPage.tsx
+++ b/native/app/inventory/pages/InventoryPage.tsx
@@ -9,8 +9,6 @@ import { useGGStore } from "@/app/store/GGStore.ts";
 import { debounce } from "@/app/utilities/Helpers.ts";
 import { UiCellRenderItem } from "@/app/inventory/UiRowRenderItem.tsx";
 
-const pageEstimatedFlashListItemSize = [84, 84, 84, 84];
-
 function calcCurrentListIndex(posX: number, PAGE_WIDTH: number) {
   const internalOffset = posX - PAGE_WIDTH / 2;
   let index = 0;
@@ -25,6 +23,7 @@ function calcCurrentListIndex(posX: number, PAGE_WIDTH: number) {
 
 type Props = {
   readonly inventoryPages: InventoryPageEnums;
+  readonly pageEstimatedFlashListItemSize: number[];
 };
 
 const rootStyles = StyleSheet.create({
@@ -38,7 +37,7 @@ const rootStyles = StyleSheet.create({
 const keyExtractor = (item: UISections) => item.id;
 const getItemType = (item: UISections) => item.type;
 
-export default function InventoryPage({ inventoryPages }: Props) {
+export default function InventoryPage({ inventoryPages, pageEstimatedFlashListItemSize }: Props) {
   "use memo";
   const currentListIndex = useGGStore((state) => state.currentListIndex);
   const { width } = useWindowDimensions();

--- a/native/app/inventory/pages/WeaponsPage.tsx
+++ b/native/app/inventory/pages/WeaponsPage.tsx
@@ -3,5 +3,7 @@ import InventoryPage from "@/app/inventory/pages/InventoryPage.tsx";
 
 export default function WeaponsPage() {
   "use memo";
-  return <InventoryPage inventoryPages={InventoryPageEnums.Weapons} />;
+  return (
+    <InventoryPage inventoryPages={InventoryPageEnums.Weapons} pageEstimatedFlashListItemSize={[150, 150, 150, 82]} />
+  );
 }

--- a/native/app/inventory/sections/CharacterEquipmentUI.tsx
+++ b/native/app/inventory/sections/CharacterEquipmentUI.tsx
@@ -10,14 +10,13 @@ import {
 import type { EquipSection } from "@/app/inventory/logic/Helpers.ts";
 import DestinyCell from "@/app/inventory/cells/DestinyCell.tsx";
 
-const array9 = Array.from({ length: 9 });
-
 type Props = {
   readonly equipSection: EquipSection;
 };
 
 export default function CharacterEquipmentUI({ equipSection }: Props) {
   "use memo";
+
   return (
     <View style={styles.root}>
       <View style={styles.equipAndInventoryHolder}>
@@ -25,13 +24,15 @@ export default function CharacterEquipmentUI({ equipSection }: Props) {
           <DestinyCell destinyItem={equipSection.equipped} />
         </View>
         <View style={styles.inventoryGrid}>
-          {array9.map((_, index) => {
-            const item = equipSection.inventory[index];
-            return (
-              // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
-              <DestinyCell key={index} destinyItem={item} />
-            );
-          })}
+          <DestinyCell destinyItem={equipSection.inventory[0]} />
+          <DestinyCell destinyItem={equipSection.inventory[1]} />
+          <DestinyCell destinyItem={equipSection.inventory[2]} />
+          <DestinyCell destinyItem={equipSection.inventory[3]} />
+          <DestinyCell destinyItem={equipSection.inventory[4]} />
+          <DestinyCell destinyItem={equipSection.inventory[5]} />
+          <DestinyCell destinyItem={equipSection.inventory[6]} />
+          <DestinyCell destinyItem={equipSection.inventory[7]} />
+          <DestinyCell destinyItem={equipSection.inventory[8]} />
         </View>
       </View>
       <View style={styles.footer} />
@@ -42,7 +43,7 @@ export default function CharacterEquipmentUI({ equipSection }: Props) {
 const styles = StyleSheet.create({
   root: {
     width: DEFAULT_SECTION_4_WIDTH,
-
+    height: EQUIP_SECTION_HEIGHT + FOOTER_HEIGHT,
     alignSelf: "center",
   },
   footer: {


### PR DESCRIPTION
The weapons and armor page showed a jump on first render. This was due to a global size of list items being used. Page specific numbers fix the issue.