### PR TITLE
refactor: Prep auth for multiple accounts

### DIFF
--- a/native/app/bungie/Account.ts
+++ b/native/app/bungie/Account.ts
@@ -1,9 +1,7 @@
-import { parse } from "valibot";
-
 import type { AuthToken } from "@/app/store/Authentication/Utilities.ts";
 import { apiKey } from "@/constants/env.ts";
 import type { BungieUser } from "../inventory/logic/Types.ts";
-import { BungieProfileSchema, type BungieProfile, type LinkedProfiles } from "@/app/core/ApiResponse.ts";
+import type { BungieProfile } from "@/app/core/ApiResponse.ts";
 
 export async function getLinkedProfiles(authToken: AuthToken, getAllAccounts = false): Promise<JSON> {
   const headers = new Headers();
@@ -41,28 +39,12 @@ export async function getLinkedProfiles(authToken: AuthToken, getAllAccounts = f
   });
 }
 
-export function getBungieUser(linkedProfiles: LinkedProfiles): BungieUser {
-  const profiles = linkedProfiles.Response?.profiles;
-
-  try {
-    if (profiles) {
-      const bungieProfile: BungieProfile = parse(BungieProfileSchema, profiles[0]);
-
-      return {
-        supplementalDisplayName: linkedProfiles.Response.bnetMembership.supplementalDisplayName,
-        iconPath: linkedProfiles.Response.bnetMembership.iconPath,
-        topLevelAccountMembershipId: linkedProfiles.Response.bnetMembership.membershipId,
-        profile: {
-          membershipId: bungieProfile.membershipId,
-          membershipType: bungieProfile.membershipType,
-          displayName: bungieProfile.displayName,
-        },
-      };
-    }
-    console.error("No profiles found");
-    throw new Error("Unable to find valid Destiny 2 user");
-  } catch (e) {
-    console.error(e);
-    throw new Error("Unable to find valid Destiny 2 user");
-  }
+export function getBungieUser(bungieProfile: BungieProfile): BungieUser {
+  return {
+    profile: {
+      membershipId: bungieProfile.membershipId,
+      membershipType: bungieProfile.membershipType,
+      displayName: bungieProfile.displayName,
+    },
+  };
 }

--- a/native/app/core/ApiResponse.ts
+++ b/native/app/core/ApiResponse.ts
@@ -123,3 +123,6 @@ export const linkedProfilesSchema = object({
 });
 
 export type LinkedProfiles = InferOutput<typeof linkedProfilesSchema>;
+
+const BungieMembershipProfiles = array(BungieProfileSchema);
+export type BungieMembershipProfiles = InferOutput<typeof BungieMembershipProfiles>;

--- a/native/app/inventory/logic/Types.ts
+++ b/native/app/inventory/logic/Types.ts
@@ -37,9 +37,6 @@ export type VaultData = {
 };
 
 export const BungieUserSchema = object({
-  supplementalDisplayName: string(),
-  iconPath: string(),
-  topLevelAccountMembershipId: string(),
   profile: object({
     membershipId: string(),
     membershipType: number(),


### PR DESCRIPTION
The previous flow only worked for accounts with a single cross save account. For accounts where the user needs to select the Destiny 2 account the system would break.

Further changes were needed as the process is async. A list of accounts needs to be shown and then the user selects the correct one.

This was done in an over 'clever' way in Ishtar and GG was heading down the same path. This makes the login more complex, as in the total number of functions. But removes the 'clever' part.