### PR TITLE
fix: findDestinyItem would crash on fail

### DIFF
--- a/native/app/inventory/pages/details/DetailsView.tsx
+++ b/native/app/inventory/pages/details/DetailsView.tsx
@@ -47,10 +47,15 @@ export default function DetailsView({ route, navigation }: Props) {
 
   useEffect(() => {
     if (focus) {
-      const maxQuantityToTransfer = useGGStore.getState().findMaxQuantityToTransfer(destinyItem);
-      useGGStore.getState().setQuantityToTransfer(maxQuantityToTransfer);
+      if (destinyItem) {
+        const maxQuantityToTransfer = useGGStore.getState().findMaxQuantityToTransfer(destinyItem);
+        useGGStore.getState().setQuantityToTransfer(maxQuantityToTransfer);
+      } else {
+        navigation.goBack();
+        useGGStore.getState().showSnackBar("Failed to find item");
+      }
     }
-  }, [focus, destinyItem]);
+  }, [focus, destinyItem, navigation]);
 
   function transfer(targetId: CharacterId, equipOnTarget = false) {
     const transferQuantity = useGGStore.getState().quantityToTransfer;


### PR DESCRIPTION
This makes two changes. The first is that if the vault or character search returns nothihng then all other characters are searched. The second is that instead of throwing an error the function now returns null.