### PR TITLE
fix: pointless re-render of the general page

### DIFF
--- a/native/app/inventory/UiRowRenderItem.tsx
+++ b/native/app/inventory/UiRowRenderItem.tsx
@@ -15,7 +15,7 @@ type Props = {
 export const UiCellRenderItem = ({ item }: Props) => {
   switch (item.type) {
     case UISection.Separator:
-      return <SeparatorUI label={item.label} info={item.info} />;
+      return <SeparatorUI label={item.label} />;
     case UISection.CharacterEquipment:
       return <CharacterEquipmentUI equipSection={item} />;
     case UISection.Engrams:

--- a/native/app/inventory/logic/Helpers.ts
+++ b/native/app/inventory/logic/Helpers.ts
@@ -114,7 +114,8 @@ export type BaseSection = {
 export type SeparatorSection = BaseSection & {
   type: UISection.Separator;
   label: string;
-  info?: string;
+  bucketHash: BucketHash;
+  characterId: CharacterId;
 };
 
 export type EngramsSection = BaseSection & {

--- a/native/app/inventory/logic/Types.ts
+++ b/native/app/inventory/logic/Types.ts
@@ -42,7 +42,6 @@ export const BungieUserSchema = object({
 export type BungieUser = InferOutput<typeof BungieUserSchema>;
 
 export type ItemInstance = {
-  id: string;
   icon: string;
   screenshot: string;
   calculatedWaterMark?: string;

--- a/native/app/store/Account/AccountSlice.ts
+++ b/native/app/store/Account/AccountSlice.ts
@@ -387,7 +387,6 @@ function addDefinition(
     deepSightResonance: false,
     masterwork: false,
     primaryStat: 0,
-    id: baseItem.itemInstanceId ?? Math.random().toString(),
     search: "",
   };
 

--- a/native/app/store/InventoryLogic.ts
+++ b/native/app/store/InventoryLogic.ts
@@ -13,7 +13,6 @@ import {
   setMods,
 } from "@/app/store/Definitions.ts";
 import {
-  BUCKET_SIZES,
   GLOBAL_CONSUMABLES_CHARACTER_ID,
   GLOBAL_MODS_CHARACTER_ID,
   VAULT_CHARACTER_ID,
@@ -151,25 +150,13 @@ function buildUIData(get: AccountSliceGetter, inventoryPage: InventoryPageEnums)
       const sectionDetails = getSectionDetails(bucket);
       const bucketItems = characterData.items.get(bucket);
 
-      // TODO: replace switch that relies on drop through, with a check of these buckets
-      const getInfo = (bucket: SectionBuckets): string | undefined => {
-        switch (bucket) {
-          case SectionBuckets.Consumables:
-          case SectionBuckets.Mods:
-          case SectionBuckets.LostItem:
-            return `${bucketItems?.inventory.length}/${BUCKET_SIZES[bucket]}`;
-          default:
-            return undefined;
-        }
-      };
-
-      const info: string | undefined = getInfo(bucket);
       // create section separators
       const separator: SeparatorSection = {
         id: `${bucket}_separator`,
         type: UISection.Separator,
         label: sectionDetails.label,
-        info,
+        bucketHash: bucket,
+        characterId,
       };
       dataArray.push(separator);
 
@@ -259,7 +246,6 @@ function returnVaultUiData(
 ): UISections[] {
   const sectionBuckets = getSectionBuckets(inventoryPage);
   const dataArray: UISections[] = [];
-  const totalVaultItems = calcTotalVaultItems();
 
   const guardianDetails: GuardianDetailsSection = {
     id: "guardian_details",
@@ -276,7 +262,8 @@ function returnVaultUiData(
         id: `${bucket}_separator`,
         type: UISection.Separator,
         label: sectionDetails.label,
-        info: `${totalVaultItems}/${BUCKET_SIZES[SectionBuckets.Vault]}`,
+        bucketHash: bucket,
+        characterId: VAULT_CHARACTER_ID,
       };
       dataArray.push(separator);
 
@@ -321,7 +308,7 @@ function getLootSections(items: DestinyItem[], id: string): LootSection[] {
   return LootSections;
 }
 
-function calcTotalVaultItems(): number {
+export function calcTotalVaultItems(): number {
   let total = 0;
   for (const bucket of section_buckets) {
     const section = generalVault.get(bucket as number);


### PR DESCRIPTION
This was caused by a random ID that isn't even needed and storing the vault size. Vault contents can change from the other pages even though the general valut pages themselves were untouched.