### PR TITLE
refactor: Calc seperator values via zustand

### DIFF
--- a/native/app/inventory/UiRowRenderItem.tsx
+++ b/native/app/inventory/UiRowRenderItem.tsx
@@ -15,7 +15,7 @@ type Props = {
 export const UiCellRenderItem = ({ item }: Props) => {
   switch (item.type) {
     case UISection.Separator:
-      return <SeparatorUI label={item.label} />;
+      return <SeparatorUI label={item.label} bucketHash={item.bucketHash} characterId={item.characterId} />;
     case UISection.CharacterEquipment:
       return <CharacterEquipmentUI equipSection={item} />;
     case UISection.Engrams:

--- a/native/app/inventory/logic/Helpers.ts
+++ b/native/app/inventory/logic/Helpers.ts
@@ -77,6 +77,22 @@ export const equipSectionBuckets = [
   SectionBuckets.Finisher,
 ];
 
+export const vaultItemBuckets = [
+  SectionBuckets.Kinetic,
+  SectionBuckets.Energy,
+  SectionBuckets.Power,
+  SectionBuckets.Ghost,
+  SectionBuckets.Helmet,
+  SectionBuckets.Gauntlets,
+  SectionBuckets.Chest,
+  SectionBuckets.Leg,
+  SectionBuckets.Class,
+  SectionBuckets.Ship,
+  SectionBuckets.Vehicle,
+  SectionBuckets.Mods,
+  SectionBuckets.Consumables,
+];
+
 export const lightLevelBuckets = [
   SectionBuckets.Kinetic,
   SectionBuckets.Energy,

--- a/native/app/inventory/sections/SeparatorUI.tsx
+++ b/native/app/inventory/sections/SeparatorUI.tsx
@@ -1,20 +1,90 @@
 import { StyleSheet, View, Text } from "react-native";
 
 import { SEPARATOR_HEIGHT, DEFAULT_MARGIN } from "@/app/utilities/UISize.ts";
+import { useGGStore } from "@/app/store/GGStore.ts";
+import { BUCKET_SIZES, VAULT_CHARACTER_ID } from "@/app/utilities/Constants.ts";
+import type { BucketHash, CharacterId } from "@/app/core/GetProfile.ts";
+import { vaultItemBuckets } from "@/app/inventory/logic/Helpers.ts";
+import { useEffect, useState } from "react";
+import { SectionBuckets } from "@/app/bungie/Enums.ts";
 
 type Props = {
   readonly label: string;
-  readonly info?: string;
+  readonly bucketHash?: BucketHash;
+  readonly characterId?: CharacterId;
 };
 
-export default function SeparatorUI({ label, info }: Props) {
+export default function SeparatorUI({ label, bucketHash, characterId }: Props) {
   "use memo";
+
+  const [info, setInfo] = useState("");
+
+  useEffect(() => {
+    if (bucketHash && characterId === VAULT_CHARACTER_ID && vaultItemBuckets.includes(bucketHash)) {
+      const unsubscribe = useGGStore.subscribe(
+        (state) => state.ggVaultCount,
+        (vaultCount, previousVaultCount) => {
+          if (info === "" || vaultCount !== previousVaultCount) {
+            const totalVaultItems = useGGStore.getState().ggVaultCount;
+            setInfo(`${totalVaultItems}/${BUCKET_SIZES[SectionBuckets.Vault]}`);
+          }
+        },
+        { fireImmediately: true },
+      );
+
+      return unsubscribe;
+    }
+
+    if (characterId && bucketHash === SectionBuckets.LostItem && characterId !== VAULT_CHARACTER_ID) {
+      const characterIndex = useGGStore.getState().getCharacterIndex(characterId);
+      const unsubscribe = useGGStore.subscribe(
+        (state) => state.ggLostItemCount[characterIndex],
+        (lostItemsCount, previousLostItemsCount) => {
+          if (info === "" || lostItemsCount !== previousLostItemsCount) {
+            setInfo(`${lostItemsCount}/${BUCKET_SIZES[SectionBuckets.LostItem]}`);
+          }
+        },
+        { fireImmediately: true },
+      );
+
+      return unsubscribe;
+    }
+
+    if (characterId && bucketHash === SectionBuckets.Mods && characterId !== VAULT_CHARACTER_ID) {
+      const unsubscribe = useGGStore.subscribe(
+        (state) => state.ggModsCount,
+        (modsCount, previousModsCount) => {
+          if (info === "" || modsCount !== previousModsCount) {
+            setInfo(`${modsCount}/${BUCKET_SIZES[SectionBuckets.Mods]}`);
+          }
+        },
+        { fireImmediately: true },
+      );
+
+      return unsubscribe;
+    }
+
+    if (characterId && bucketHash === SectionBuckets.Consumables && characterId !== VAULT_CHARACTER_ID) {
+      const unsubscribe = useGGStore.subscribe(
+        (state) => state.ggConsumablesCount,
+        (consumablesCount, previousConsumablesCount) => {
+          if (info === "" || consumablesCount !== previousConsumablesCount) {
+            setInfo(`${consumablesCount}/${BUCKET_SIZES[SectionBuckets.Consumables]}`);
+          }
+        },
+        { fireImmediately: true },
+      );
+
+      return unsubscribe;
+    }
+  }, [bucketHash, characterId, info]);
+
   return (
     <View style={styles.root}>
       <View style={styles.spacer} />
       <View style={{ flexDirection: "row", justifyContent: "space-between" }}>
         <Text style={styles.label}>{label}</Text>
-        {info && <Text style={styles.label}>{info}</Text>}
+        {true && <Text style={styles.label}>{`${info}`}</Text>}
       </View>
       <View style={styles.spacer2} />
       <View style={styles.bar} />

--- a/native/app/inventory/sections/SeparatorUI.tsx
+++ b/native/app/inventory/sections/SeparatorUI.tsx
@@ -84,7 +84,7 @@ export default function SeparatorUI({ label, bucketHash, characterId }: Props) {
       <View style={styles.spacer} />
       <View style={{ flexDirection: "row", justifyContent: "space-between" }}>
         <Text style={styles.label}>{label}</Text>
-        {true && <Text style={styles.label}>{`${info}`}</Text>}
+        <Text style={styles.label}>{`${info}`}</Text>
       </View>
       <View style={styles.spacer2} />
       <View style={styles.bar} />

--- a/native/app/store/Account/AccountSlice.ts
+++ b/native/app/store/Account/AccountSlice.ts
@@ -79,6 +79,10 @@ export interface AccountSlice {
   ggWeapons: UISections[][];
   ggArmor: UISections[][];
   ggGeneral: UISections[][];
+  ggLostItemCount: number[];
+  ggVaultCount: number;
+  ggModsCount: number;
+  ggConsumablesCount: number;
 
   selectedItem: DestinyItem | null;
   quantityToTransfer: number;
@@ -118,6 +122,10 @@ export const createAccountSlice: StateCreator<IStore, [], [], AccountSlice> = (s
   ggWeapons: [],
   ggArmor: [],
   ggGeneral: [],
+  ggLostItemCount: [],
+  ggVaultCount: 0,
+  ggModsCount: 0,
+  ggConsumablesCount: 0,
 
   selectedItem: null,
   quantityToTransfer: 1,


### PR DESCRIPTION
This was needed as previously the info was a property of the data used to build the flashlists. This meant all the pages would be updated as items transfered. Now with bindings only shown pages that have changed will update.