### PR TITLE
fix: property access before definitions are ready

### DIFF
--- a/native/app/inventory/logic/Helpers.ts
+++ b/native/app/inventory/logic/Helpers.ts
@@ -197,6 +197,6 @@ export const ArmorStatInvestments = [
 ];
 
 export function getSectionDetails(bucket: SectionBuckets): { label: string; icon: string } {
-  const section = DestinyInventoryBucketDefinition[bucket]?.displayProperties?.name ?? "";
+  const section = DestinyInventoryBucketDefinition?.[bucket]?.displayProperties?.name ?? "";
   return { label: `\\ ${section}`, icon: iconUrl };
 }


### PR DESCRIPTION
This seems to only happen when Google are auto testing the app. Not in the real world.