### PR TITLE
refactor: Improve start up

### DIFF
--- a/native/app/App.tsx
+++ b/native/app/App.tsx
@@ -1,23 +1,14 @@
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import * as SplashScreen from "expo-splash-screen";
 
 import MainDrawer from "@/app/UI/MainDrawer.tsx";
 import Login from "@/app/UI/Login.tsx";
 import DetailsView from "@/app/inventory/pages/details/DetailsView.tsx";
 import type { RootStackParamList } from "@/app/Root.tsx";
-import { useGGStore } from "@/app/store/GGStore.ts";
 
 const RootStack = createNativeStackNavigator<RootStackParamList>();
 
 function App() {
   "use memo";
-
-  const stateHydrated = useGGStore((state) => state.stateHydrated);
-
-  if (!stateHydrated) {
-    return null;
-  }
-  SplashScreen.hideAsync();
 
   return (
     <RootStack.Navigator>

--- a/native/app/App.web.tsx
+++ b/native/app/App.web.tsx
@@ -4,7 +4,6 @@ import MainDrawer from "@/app/UI/MainDrawer.tsx";
 import Login from "@/app/UI/Login.tsx";
 import DetailsView from "@/app/inventory/pages/details/DetailsView.tsx";
 import type { RootStackParamList } from "@/app/Root.tsx";
-import { useGGStore } from "@/app/store/GGStore.ts";
 
 // Native app uses a native stack navigator which has no animations on web.
 // so this is a workaround to get the animations working.
@@ -22,12 +21,6 @@ function App() {
   "use memo";
 
   injectWebCss();
-
-  const stateHydrated = useGGStore((state) => state.stateHydrated);
-
-  if (!stateHydrated) {
-    return null;
-  }
 
   return (
     <RootStack.Navigator screenOptions={{ animationEnabled: true }}>

--- a/native/app/Root.tsx
+++ b/native/app/Root.tsx
@@ -145,6 +145,7 @@ function Root() {
   useEffect(() => {
     if (authenticated === "NO-AUTHENTICATION" && stateHydrated) {
       if (navigationRef.current) {
+        SplashScreen.hideAsync();
         navigationRef.current.navigate("Login");
       } else {
         console.error("No navigationRef");

--- a/native/app/UI/MainDrawer.tsx
+++ b/native/app/UI/MainDrawer.tsx
@@ -2,6 +2,7 @@ import { type DrawerContentComponentProps, createDrawerNavigator, DrawerItem } f
 import { Image } from "expo-image";
 import { Platform, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import * as Haptics from "expo-haptics";
+import * as SplashScreen from "expo-splash-screen";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { useGGStore } from "@/app/store/GGStore.ts";
@@ -169,6 +170,13 @@ function CustomDrawerContent({ navigation, state }: DrawerContentComponentProps)
 
 export default function MainDrawer() {
   "use memo";
+
+  const appReady = useGGStore((state) => state.appReady);
+
+  if (!appReady) {
+    return null;
+  }
+  SplashScreen.hideAsync();
 
   return (
     <Drawer.Navigator

--- a/native/app/store/Account/AccountSlice.ts
+++ b/native/app/store/Account/AccountSlice.ts
@@ -70,6 +70,7 @@ export type AccountSliceGetter = Parameters<StateCreator<IStore, [], [], Account
 
 export interface AccountSlice {
   stateHydrated: boolean;
+  appReady: boolean;
 
   appStartupTime: number;
   refreshing: boolean;
@@ -131,6 +132,7 @@ export interface AccountSlice {
 
 export const createAccountSlice: StateCreator<IStore, [], [], AccountSlice> = (set, get) => ({
   stateHydrated: false,
+  appReady: false,
 
   appStartupTime: 0,
   refreshing: false,
@@ -169,6 +171,9 @@ export const createAccountSlice: StateCreator<IStore, [], [], AccountSlice> = (s
   setInitialAccountDataReady: () => {
     if (!get().initialAccountDataReady) {
       set({ initialAccountDataReady: true });
+      if (get().itemsDefinitionReady && get().bungieDefinitionsReady) {
+        set({ appReady: true });
+      }
     }
   },
   setAppStartupTime: (appStartupTime) => set({ appStartupTime }),


### PR DESCRIPTION
This change creates a new state variable 'appReady'. This is true when the state has hydrated and both the custom item defintion and bungie definitions have all successfully been downloaded or on app restart loaded.

The MainDrawer UI will not be shown till the app is ready making it impossible for the auto refresh or manual refresh to be activated.

The splash screen is then only hidden when the app is ready. And exception to this is when the app is not authenticated. In this case the splash is dimissed and then the login screen is shown.