### PR TITLE
fix: Possible fix for manifest download fail

### DIFF
--- a/native/app/Root.tsx
+++ b/native/app/Root.tsx
@@ -12,7 +12,8 @@ import { enableScreens } from "react-native-screens";
 // Enable screens for better performance
 enableScreens();
 
-import { BUNGIE_MANIFEST_URL, CUSTOM_MANIFEST_URL, getFullProfile, getJsonBlob } from "@/app/bungie/BungieApi.ts";
+import { BUNGIE_MANIFEST_URL, CUSTOM_MANIFEST_URL, getFullProfile } from "@/app/bungie/BungieApi.ts";
+import { getJsonBlob } from "@/app/utilities/Helpers.ts";
 import { useGGStore } from "@/app/store/GGStore.ts";
 import { bungieManifestSchema } from "@/app/core/ApiResponse.ts";
 import type { DestinyItemIdentifier } from "@/app/inventory/logic/Helpers.ts";
@@ -50,7 +51,7 @@ async function getCustomItemDefinition() {
 let bungieDownloadAttempts = 0;
 async function getBungieDefinitions() {
   try {
-    const bungieManifest = getJsonBlob(BUNGIE_MANIFEST_URL);
+    const bungieManifest = getJsonBlob(BUNGIE_MANIFEST_URL, true);
     const manifest = await bungieManifest;
     const parsedManifest = parse(bungieManifestSchema, manifest);
     await useGGStore.getState().loadBungieDefinitions(parsedManifest);

--- a/native/app/bungie/BungieApi.ts
+++ b/native/app/bungie/BungieApi.ts
@@ -108,23 +108,3 @@ export async function getProfile(): Promise<JSON> {
     throw new Error("Unknown error occurred");
   }
 }
-
-export function getJsonBlob(jsonUrl: string): Promise<JSON> {
-  return new Promise((resolve, reject) => {
-    fetch(jsonUrl)
-      .then((response) => {
-        if (!response.ok) {
-          console.error(response);
-          throw new Error(`HTTP error! Status: ${response.status}`);
-        }
-        return response.json();
-      })
-      .then((data) => {
-        resolve(data);
-      })
-      .catch((error) => {
-        console.error("Failed to download getJsonBlog", error);
-        reject(new Error("Failed to download getJsonBlog", error));
-      });
-  });
-}

--- a/native/app/store/DefinitionsSlice.ts
+++ b/native/app/store/DefinitionsSlice.ts
@@ -59,6 +59,7 @@ import {
 import { bungieUrl, type BungieManifest } from "@/app/core/ApiResponse.ts";
 import type { ItemHash } from "@/app/core/GetProfile.ts";
 import { updateBucketSizes, updateDestinyText } from "@/app/utilities/Constants.ts";
+import { getJsonBlob } from "@/app/utilities/Helpers.ts";
 
 export type DefinitionsSliceSetter = Parameters<StateCreator<IStore, [], [], DefinitionsSlice>>[0];
 export type DefinitionsSliceGetter = Parameters<StateCreator<IStore, [], [], DefinitionsSlice>>[1];
@@ -219,7 +220,7 @@ async function downloadAndStoreBungieDefinitions(
 
       if (path) {
         const url = `${bungieUrl}${path}`;
-        const downloadedDefinition = getBungieDefinition(url);
+        const downloadedDefinition = getJsonBlob(url, true);
         promises.push(downloadedDefinition);
       }
     }
@@ -546,28 +547,4 @@ export async function setAsyncStorage(key: AsyncStorageKey, data: string): Promi
     console.error("Failed to save", error, key);
     throw new Error(`Failed to save AsyncStorage ${key}`);
   }
-}
-
-async function getBungieDefinition(definitionUrl: string): Promise<JSON> {
-  const requestOptions: RequestInit = {
-    method: "GET",
-  };
-
-  return new Promise((resolve, reject) => {
-    fetch(definitionUrl, requestOptions)
-      .then((response) => {
-        if (!response.ok) {
-          console.error(response);
-          throw new Error(`HTTP error! Status: ${response.status}`);
-        }
-        return response.json();
-      })
-      .then((data) => {
-        resolve(data);
-      })
-      .catch((error) => {
-        console.error("getBungieDefinition", definitionUrl, error);
-        reject(new Error(`getBungieDefinition Error ${error}`));
-      });
-  });
 }

--- a/native/app/store/DefinitionsSlice.ts
+++ b/native/app/store/DefinitionsSlice.ts
@@ -220,7 +220,7 @@ async function downloadAndStoreBungieDefinitions(
 
       if (path) {
         const url = `${bungieUrl}${path}`;
-        const downloadedDefinition = getJsonBlob(url, true);
+        const downloadedDefinition = getJsonBlob(url);
         promises.push(downloadedDefinition);
       }
     }

--- a/native/app/utilities/Helpers.ts
+++ b/native/app/utilities/Helpers.ts
@@ -1,5 +1,6 @@
 import { GuardianClassType } from "@/app/bungie/Enums.ts";
 import type { DestinyItemSort } from "@/app/inventory/logic/Types.ts";
+import { apiKey } from "@/constants/env.ts";
 
 declare const __brand: unique symbol;
 type Brand<B> = { [__brand]: B };
@@ -523,4 +524,34 @@ export function getGuardianRaceType(raceType: number) {
     default:
       return "";
   }
+}
+
+export function getJsonBlob(jsonUrl: string, includeHeaders?: boolean): Promise<JSON> {
+  const headers = new Headers();
+  if (includeHeaders) {
+    headers.append("X-API-Key", apiKey);
+    headers.append("Accept", "application/json");
+  }
+
+  const requestOptions: RequestInit = {
+    method: "GET",
+    headers: headers,
+  };
+  return new Promise((resolve, reject) => {
+    fetch(jsonUrl, requestOptions)
+      .then((response) => {
+        if (!response.ok) {
+          console.error(response);
+          throw new Error(`HTTP error! Status: ${response.status}`);
+        }
+        return response.json();
+      })
+      .then((data) => {
+        resolve(data);
+      })
+      .catch((error) => {
+        console.error("Failed to download getJsonBlog", error);
+        reject(new Error("Failed to download getJsonBlog", error));
+      });
+  });
 }


### PR DESCRIPTION
It is unclear why attempting to download the manifest can result in a rare 500 error. 

This attempts to fix the issue by passing the api key the error says is missing. It also refactors the code to remove a duplicate function called getBungieDefinition.

Finally getJSONblob was moved to stop a circular dependency warning.