### PR TITLE
fix: weapons not updating on sort

### DIFF
--- a/native/app/store/InventoryLogic.ts
+++ b/native/app/store/InventoryLogic.ts
@@ -450,7 +450,7 @@ export function returnBorderColor(item: DestinyItem): string {
 }
 
 function sortInventoryArray(get: AccountSliceGetter, dataArray: DestinyItem[], bucketHash: BucketHash): DestinyItem[] {
-  let existingArray = dataArray as DestinyItemSort[];
+  let existingArray = dataArray.slice(0) as DestinyItemSort[];
   if (weaponBuckets.includes(bucketHash)) {
     const weaponsSort = get().weaponsSort;
     switch (weaponsSort) {


### PR DESCRIPTION
Due to array mutation. Now array is copied and then sorted so the changes are detected.