### PR TITLE
chore: Turn off app hang tracking in Sentry

### DIFF
--- a/native/app/index.js
+++ b/native/app/index.js
@@ -21,6 +21,7 @@ Sentry.init({
   enabled: !__DEV__,
   attachScreenshot: true,
   enableAutoSessionTracking: true,
+  enableAppHangTracking: false,
   integrations: [new Sentry.ReactNativeTracing({ routingInstrumentation })],
   _experiments: {
     // profilesSampleRate is relative to tracesSampleRate.


### PR DESCRIPTION
Seems to have a false positive issue on iOS